### PR TITLE
修复硬编码思源笔记地址以及在 Docker 环境下使用不正常

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "siyuan-plugins-mcp-sisyphus",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "type": "module",
   "description": "Let AI control your notes with a SiYuan MCP server that exposes 7 aggregated tools with action-level routing for deep AI integration.",
   "repository": "https://github.com/yangtaihong59/siyuan-plugins-mcp-sisyphus",

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "name": "siyuan-plugins-mcp-sisyphus",
   "author": "Taihong Yang",
   "url": "https://github.com/yangtaihong59/siyuan-plugins-mcp-sisyphus",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "minAppVersion": "2.9.0",
   "backends": ["all"],
   "frontends": ["all"],

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -15,7 +15,9 @@ export class SiYuanClient {
     private token: string = '';
 
     constructor(config: SiYuanClientConfig = {}) {
-        this.baseUrl = config.baseUrl || 'http://127.0.0.1:6806';
+        this.baseUrl = config.baseUrl
+            || process.env.SIYUAN_API_URL
+            || 'http://127.0.0.1:6806';
         this.timeout = config.timeout || 30000;
     }
 
@@ -143,7 +145,7 @@ export class SiYuanClient {
             const response = await fetch(url, {
                 method: 'POST',
                 headers,
-                body: data ? JSON.stringify(data) : undefined,
+                body: JSON.stringify(data ?? {}),
                 signal: controller.signal,
             });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,13 +8,7 @@ import "./index.scss";
 import { loadPersistedToolConfig, savePersistedToolConfig } from "@/setting/tool-config-storage";
 import McpConfig from "@/setting/mcp-config.svelte";
 
-/** 思源 API 端口写死，不读写 menu-config.json */
-const MCP_API_URL = "http://127.0.0.1:6806";
-
 export default class SiyuanMCP extends Plugin {
-
-    /** 供其他模块读取，端口固定 */
-    mcpSettings = { apiUrl: MCP_API_URL };
 
     async onload() {
         const normalized = await loadPersistedToolConfig(this);

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -148,6 +148,14 @@ function asCategory(name: string): ToolCategory | null {
 async function initSiYuanClient(): Promise<SiYuanClient> {
     const client = new SiYuanClient();
 
+    // 优先使用环境变量传入的 token（Docker 鉴权场景必需）
+    const envToken = process.env.SIYUAN_TOKEN;
+    if (envToken) {
+        client.setToken(envToken);
+        return client;
+    }
+
+    // 无鉴权场景：尝试从 API 获取 token
     try {
         const token = await client.request<string>('/api/system/getApiToken', {});
         if (token) {

--- a/src/setting/mcp-config.svelte
+++ b/src/setting/mcp-config.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { onMount } from "svelte";
-    import { showMessage } from "siyuan";
+    import { fetchPost, showMessage } from "siyuan";
 
     import { buildDefaultToolConfig, isDangerousAction, normalizeToolConfig, type BlockAction, type DocumentAction, type FileAction, type NotebookAction, type SearchAction, type SystemAction, type TagAction, type ToolCategory, type ToolConfig } from "./tool-config";
     import { loadPersistedToolConfig, savePersistedToolConfig } from "./tool-config-storage";
@@ -272,13 +272,19 @@
 
     async function loadNotebooks() {
         try {
-            const resp = await fetch("http://127.0.0.1:6806/api/notebook/lsNotebooks", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({}),
+            await new Promise<void>((resolve, reject) => {
+                fetchPost("/api/notebook/lsNotebooks", {}, (resp: any) => {
+                    if (resp?.code === 0) {
+                        notebooks = (resp?.data?.notebooks ?? []).map((nb: any) => ({
+                            id: nb.id,
+                            name: nb.name,
+                        }));
+                        resolve();
+                    } else {
+                        reject(new Error(resp?.msg || "Failed to load notebooks"));
+                    }
+                });
             });
-            const json = await resp.json();
-            notebooks = (json?.data?.notebooks ?? []).map((nb: any) => ({ id: nb.id, name: nb.name }));
         } catch {
             notebooks = [];
         }


### PR DESCRIPTION
修复问题：
1. 修复代码中的硬编码思源笔记地址，改为 fetchPost自动获取；
2. 修复思源笔记带有鉴权 token 时无法正常使用的；
3. 修复在 Docker 思源环境下无法调用 API；
4. 环境变量显示提供思源笔记链接和 token，并支持多个思源笔记服务；

MCP 客户端示例：
```json
{
  "mcpServers": {
    "siyuan": {
      "command": "node",
      "args": ["{SIYUAN_PATH}/plugins/siyuan-plugins-mcp-sisyphus/mcp-server.cjs"]
      "env":{
        "SIYUAN_API_URL": "http://127.0.0.1:6806/",
        "SIYUAN_TOKEN": "xxxxxx"
      }
    }
  }
}
```

修复：https://github.com/yangtaihong59/siyuan-plugins-mcp-sisyphus/issues/5