### PR TITLE
fix(file): extract_doc 无法提取带有标题的附件 

### DIFF
--- a/src/tools/file/handlers.ts
+++ b/src/tools/file/handlers.ts
@@ -253,7 +253,7 @@ const handleExtractDoc: ToolActionHandler = async ({ client, rawArgs }) => {
     const docMdPath = path.join(targetDir, `${docName}.md`);
     fs.writeFileSync(docMdPath, markdown, 'utf-8');
 
-    const assetRefs = [...markdown.matchAll(/\]\(assets\/([^)]+)\)/g)];
+    const assetRefs = [...markdown.matchAll(/\]\(assets\/([^\s)"']+)(?:\s+"[^"]*")?\)/g)];
     const structure = [`${docName}.md`];
     let extractedCount = 0;
     let skippedCount = 0;

--- a/tests/unit/tools/file.test.ts
+++ b/tests/unit/tools/file.test.ts
@@ -217,4 +217,30 @@ describe('file tool asset actions', () => {
         expect(parsed.extractedAssetCount).toBe(0);
         expect(parsed.skippedAssetCount).toBe(1);
     });
+
+    it('extracts images with titles correctly', async () => {
+        const fileApi = await import('@/api/file');
+        vi.mocked(fileApi.exportMdContent).mockResolvedValue({
+            content: '![alt](assets/cover.png "image title")\n\nSome text\n',
+            hPath: '/My Document',
+        });
+
+        const readFileBinary = vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]));
+        const localClient = createMockClient({ readFileBinary });
+        const fs = (await import('node:fs')).default;
+        vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+        vi.spyOn(fs, 'rmSync').mockImplementation((() => undefined) as typeof fs.rmSync);
+        vi.spyOn(fs, 'mkdirSync').mockImplementation((() => undefined) as typeof fs.mkdirSync);
+        vi.spyOn(fs, 'writeFileSync').mockImplementation((() => undefined) as typeof fs.writeFileSync);
+
+        const result = await callFileTool(localClient, {
+            action: 'extract_doc',
+            id: '20260128210016-dw9cpey',
+        }, config.file, {} as never);
+
+        const parsed = parseResult(result);
+        expect(parsed.extractedAssetCount).toBe(1);
+        expect(parsed.skippedAssetCount).toBe(0);
+        expect(readFileBinary).toHaveBeenCalledWith('data/assets/cover.png');
+    });
 });


### PR DESCRIPTION
问题
extract_doc 提取文档时，如果思源中的图片设置了标题（caption），导出的 markdown 格式为：

`![alt](assets/image.png "图片标题")`
旧正则 /\]\(assets\/([^)]+)\)/g 中的 [^)]+ 把 image.png "图片标题" 整个当成了文件名，导致资源下载失败（skipped）。

修复
handlers.ts 第256行，将正则从：
`/\]\(assets\/([^)]+)\)/g`

改为：
`/\]\(assets\/([^\s)"']+)(?:\s+"[^"]*")?\)/g`

捕获组改为 ([^\s)"']+) —— 遇到空格、引号或右括号即停止，只取文件名
加 `(?:\s+"[^"]*")? `可选匹配标题部分，让正则能正确消费掉标题后的右括号

测试
新增回归测试 extracts images with titles correctly，验证 `![alt](assets/cover.png "image title") `能正确提取为 cover.png，不会把标题当文件名。全部 667 个已有测试通过，构建成功。