### PR TITLE
Fix/reduce siyuan api timeout

### DIFF
--- a/docs/architecture/modules.md
+++ b/docs/architecture/modules.md
@@ -435,7 +435,7 @@ Before dispatch, reads `plugin.json` and permission files via SiYuan API to ensu
 
 | Feature | Description |
 |---------|-------------|
-| **Instantiation** | `new SiYuanClient(config)`, `baseUrl` defaults to `http://127.0.0.1:6806`, `timeout` defaults to 30s |
+| **Instantiation** | `new SiYuanClient(config)`, `baseUrl` defaults to `http://127.0.0.1:6806`, `timeout` defaults to 5s |
 | **Token management** | `setToken()` / `getAuthHeaders()` inject `Authorization: Token <token>` |
 | **Unified request** | `request<T>(endpoint, data?)` auto-parses `SiYuanResponse<T>` (returns `data` when `code === 0`, throws `SiYuanError` otherwise) |
 | **File operations** | `readFile()` / `readFileBinary()` / `writeFile()` (FormData + File upload) |

--- a/docs/architecture/modules.md
+++ b/docs/architecture/modules.md
@@ -435,7 +435,7 @@ Before dispatch, reads `plugin.json` and permission files via SiYuan API to ensu
 
 | Feature | Description |
 |---------|-------------|
-| **Instantiation** | `new SiYuanClient(config)`, `baseUrl` defaults to `http://127.0.0.1:6806`, `timeout` defaults to 5s |
+| **Instantiation** | `new SiYuanClient(config)`, `baseUrl` defaults to `http://127.0.0.1:6806`, `timeout` defaults to 2s |
 | **Token management** | `setToken()` / `getAuthHeaders()` inject `Authorization: Token <token>` |
 | **Unified request** | `request<T>(endpoint, data?)` auto-parses `SiYuanResponse<T>` (returns `data` when `code === 0`, throws `SiYuanError` otherwise) |
 | **File operations** | `readFile()` / `readFileBinary()` / `writeFile()` (FormData + File upload) |

--- a/docs/architecture/modules.md
+++ b/docs/architecture/modules.md
@@ -435,7 +435,7 @@ Before dispatch, reads `plugin.json` and permission files via SiYuan API to ensu
 
 | Feature | Description |
 |---------|-------------|
-| **Instantiation** | `new SiYuanClient(config)`, `baseUrl` defaults to `http://127.0.0.1:6806`, `timeout` defaults to 2s |
+| **Instantiation** | `new SiYuanClient(config)`, `baseUrl` defaults to `http://127.0.0.1:6806`, `timeout` defaults to 5s |
 | **Token management** | `setToken()` / `getAuthHeaders()` inject `Authorization: Token <token>` |
 | **Unified request** | `request<T>(endpoint, data?)` auto-parses `SiYuanResponse<T>` (returns `data` when `code === 0`, throws `SiYuanError` otherwise) |
 | **File operations** | `readFile()` / `readFileBinary()` / `writeFile()` (FormData + File upload) |

--- a/docs/zh/architecture/modules.md
+++ b/docs/zh/architecture/modules.md
@@ -435,7 +435,7 @@ CLI flag (--url / --token)
 
 | 特性 | 说明 |
 |------|------|
-| **实例化** | `new SiYuanClient(config)`，`baseUrl` 默认 `http://127.0.0.1:6806`，`timeout` 默认 5s |
+| **实例化** | `new SiYuanClient(config)`，`baseUrl` 默认 `http://127.0.0.1:6806`，`timeout` 默认 2s |
 | **Token 管理** | `setToken()` / `getAuthHeaders()` 注入 `Authorization: Token <token>` |
 | **统一请求** | `request<T>(endpoint, data?)` 自动解析 `SiYuanResponse<T>`（`code === 0` 返回 `data`，否则抛 `SiYuanError`） |
 | **文件操作** | `readFile()` / `readFileBinary()` / `writeFile()`（FormData + File 上传） |

--- a/docs/zh/architecture/modules.md
+++ b/docs/zh/architecture/modules.md
@@ -435,7 +435,7 @@ CLI flag (--url / --token)
 
 | 特性 | 说明 |
 |------|------|
-| **实例化** | `new SiYuanClient(config)`，`baseUrl` 默认 `http://127.0.0.1:6806`，`timeout` 默认 30s |
+| **实例化** | `new SiYuanClient(config)`，`baseUrl` 默认 `http://127.0.0.1:6806`，`timeout` 默认 5s |
 | **Token 管理** | `setToken()` / `getAuthHeaders()` 注入 `Authorization: Token <token>` |
 | **统一请求** | `request<T>(endpoint, data?)` 自动解析 `SiYuanResponse<T>`（`code === 0` 返回 `data`，否则抛 `SiYuanError`） |
 | **文件操作** | `readFile()` / `readFileBinary()` / `writeFile()`（FormData + File 上传） |

--- a/docs/zh/architecture/modules.md
+++ b/docs/zh/architecture/modules.md
@@ -435,7 +435,7 @@ CLI flag (--url / --token)
 
 | 特性 | 说明 |
 |------|------|
-| **实例化** | `new SiYuanClient(config)`，`baseUrl` 默认 `http://127.0.0.1:6806`，`timeout` 默认 2s |
+| **实例化** | `new SiYuanClient(config)`，`baseUrl` 默认 `http://127.0.0.1:6806`，`timeout` 默认 5s |
 | **Token 管理** | `setToken()` / `getAuthHeaders()` 注入 `Authorization: Token <token>` |
 | **统一请求** | `request<T>(endpoint, data?)` 自动解析 `SiYuanResponse<T>`（`code === 0` 返回 `data`，否则抛 `SiYuanError`） |
 | **文件操作** | `readFile()` / `readFileBinary()` / `writeFile()`（FormData + File 上传） |

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -17,7 +17,7 @@ export class SiYuanClient {
             || process.env.SIYUAN_API_URL
             || 'http://127.0.0.1:6806';
         this.baseUrl = rawBaseUrl.replace(/\/+$/, '');
-        this.timeout = config.timeout || 30000;
+        this.timeout = config.timeout || 5000;
     }
 
     setToken(token: string): void {

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -17,7 +17,7 @@ export class SiYuanClient {
             || process.env.SIYUAN_API_URL
             || 'http://127.0.0.1:6806';
         this.baseUrl = rawBaseUrl.replace(/\/+$/, '');
-        this.timeout = config.timeout || 5000;
+        this.timeout = config.timeout || 2000;
     }
 
     setToken(token: string): void {

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -17,7 +17,7 @@ export class SiYuanClient {
             || process.env.SIYUAN_API_URL
             || 'http://127.0.0.1:6806';
         this.baseUrl = rawBaseUrl.replace(/\/+$/, '');
-        this.timeout = config.timeout || 2000;
+        this.timeout = config.timeout || 5000;
     }
 
     setToken(token: string): void {


### PR DESCRIPTION
之前修复连接稳定性时，引入了30秒*4次连接重试。如果思源在使用过程中被关闭，则MCP发出请求后需要2分钟才能知道自己连接失败，在此期间AI会一直卡在调用工具的状态。

本打算改成2秒*4次，但担心2秒可能太激进了。最后修复为5*秒*4次，加上其他网络条件，大概22秒左右能拿到报错结果。先简单修复一下，把延迟降下来，等后面有时间再处理。

之前设计的是当思源未启动时，返回“思源未启动，请提醒用户启动后再试”。但这个机制只发生在第一次注册MCP时，如果一开始MCP正常使用，后续思源被关闭，则失效，会直接卡住。

