### PR TITLE
fix🐛(build): 修复 vite 打包导致 stdio transport 不可用

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,6 +21,7 @@ const mcpAppHtmlPath = resolve(__dirname, mcpAppOutputDir, "index.html");
 const serverExternals = [
     "siyuan",
     "process",
+    "node:process",
     "path",
     "fs",
     "node:path",
@@ -165,8 +166,30 @@ function createServerConfig() {
             alias: {
                 "@": resolve(__dirname, "src"),
             },
+            conditions: ["node", "default"],
         },
-        plugins: [mcpAppHtmlModule()],
+        plugins: [
+            mcpAppHtmlModule(),
+            {
+                name: "mcp-shims-node-resolve",
+                enforce: "pre" as const,
+                resolveId(source) {
+                    if (source === "@modelcontextprotocol/server/_shims") {
+                        return { id: "\0virtual:mcp-shims-node", moduleSideEffects: false };
+                    }
+                    return null;
+                },
+                load(id) {
+                    if (id !== "\0virtual:mcp-shims-node") return null;
+                    return [
+                        'import process from "node:process";',
+                        'import { AjvJsonSchemaValidator } from "@modelcontextprotocol/server/validators/ajv";',
+                        "export { process };",
+                        "export const DefaultJsonSchemaValidator = AjvJsonSchemaValidator;",
+                    ].join("\n");
+                },
+            },
+        ],
         define: {
             "process.env.DEV_MODE": JSON.stringify(isDev),
             "process.env.NODE_ENV": JSON.stringify(env.NODE_ENV),


### PR DESCRIPTION
## Problem

The bundled `mcp-server.cjs` fails to start in stdio mode, immediately throwing:

```
[MCP] Failed to start server: StdioServerTransport is not supported in this environment. Use StreamableHTTPServerTransport instead.
```

This breaks all stdio MCP clients (Claude Desktop, VS Code, Codex, Cursor, Cline, etc.) that spawn `mcp-server.cjs` as a child process. Only the HTTP transport (`--http`) works.

## Root Cause

The MCP SDK (`@modelcontextprotocol/server@2.0.0`) exposes platform-specific shims via `@modelcontextprotocol/server/_shims`, selected through `package.json` export conditions:

| Condition | Shim | `process.stdin` |
|-----------|------|-----------------|
| `node` / `default` | `shimsNode.cjs` | real `node:process` |
| `browser` / `workerd` | `shimsBrowser.cjs` / `shimsWorkerd.cjs` | getter that throws |

`StdioServerTransport`'s constructor uses `_shims.process.stdin` as the default parameter:

```js
constructor(_stdin = _shims.process.stdin, _stdout = _shims.process.stdout, options)
```

**Issue 1:** Vite's lib mode defaults to browser compatibility and resolves `_shims` to `shimsBrowser.cjs`, whose `process.stdin` getter throws immediately on access.

**Issue 2:** Even after forcing the `node` condition via `resolve.conditions`, `shimsNode.cjs` exports `process` through a runtime getter:

```js
Object.defineProperty(exports, 'process', {
  enumerable: true,
  get: function () { return node_process.default; }
});
```

This pattern is not statically analyzable. The bundler collapses it to an empty object `{}`, so `process.stdin` becomes `undefined`, and stdio startup fails with `Cannot read properties of undefined (reading 'on')`.

## Fix

Three coordinated changes in `createServerConfig()` within `vite.config.ts`:

1. **`resolve.conditions: ["node", "default"]`** — forces the node export condition so the SDK selects `shimsNode` instead of `shimsBrowser`.

2. **Add `node:process` to `serverExternals`** — prevents Vite from externalizing `node:process` for browser compatibility (which would emit a build warning and leave the import unresolved).

3. **`mcp-shims-node-resolve` plugin** — intercepts the `@modelcontextprotocol/server/_shims` import and substitutes a virtual module that statically re-exports `process` from `node:process` and `AjvJsonSchemaValidator` from `@modelcontextprotocol/server/validators/ajv`. The static `import`/`export` form is analyzable by the bundler, so `process` survives the bundle with its real `stdin`/`stdout`.

```ts
{
    name: "mcp-shims-node-resolve",
    enforce: "pre" as const,
    resolveId(source) {
        if (source === "@modelcontextprotocol/server/_shims") {
            return { id: "\0virtual:mcp-shims-node", moduleSideEffects: false };
        }
        return null;
    },
    load(id) {
        if (id !== "\0virtual:mcp-shims-node") return null;
        return [
            'import process from "node:process";',
            'import { AjvJsonSchemaValidator } from "@modelcontextprotocol/server/validators/ajv";',
            "export { process };",
            "export const DefaultJsonSchemaValidator = AjvJsonSchemaValidator;",
        ].join("\n");
    },
},
```

### Why `DefaultJsonSchemaValidator` is re-exported

The SDK internally falls back to `new _shims.DefaultJsonSchemaValidator()` (see `mcp-D7GmuPnv.cjs`). Exporting `undefined` would cause a `TypeError` if that fallback path is ever reached. Re-exporting the real `AjvJsonSchemaValidator` keeps the shim contract complete.

## Verification

- **Before:** `node dist/mcp-server.cjs` (stdio) → `StdioServerTransport is not supported in this environment`
- **After:** `node dist/mcp-server.cjs` (stdio) → responds to `initialize` with `{"result":{"protocolVersion":"2025-06-18","serverInfo":{"name":"siyuan-mcp","version":"2.0.0"},...}}`
- **HTTP mode:** unchanged, still works via `--http`

## Scope

- Only `vite.config.ts` is modified (1 file, +24/-1).
- No `node_modules` patches — the fix is reproducible across installs and CI.
- CLI build target (`createCliConfig`) is unaffected: `src/cli/` does not import `_shims` and uses `process.argv` directly.
- The virtual module's `resolveId` returns `null` for any non-matching source, so the plugin safely no-ops for other imports.

## Notes

The deeper root cause is in the MCP SDK itself: `shimsNode.cjs` uses `Object.defineProperty` with a getter, which is not bundler-friendly. A follow-up to `@modelcontextprotocol/server` to switch to a static `exports.process = node_process.default` would let projects drop this workaround entirely. This PR is compatible with the current SDK release and can serve as a stopgap.

## Checklist

- [x] Build passes: `npm run build:server`
- [x] stdio mode verified on the bundled artifact
- [x] HTTP mode verified unchanged
- [x] CLI build target confirmed unaffected
- [x] No `node_modules` modifications
- [x] No lockfile changes