### PR TITLE
fix(ci): 统一 pnpm 版本与锁文件格式

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,8 +32,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
-        with:
-          version: 9
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,6 @@ jobs:
         uses: pnpm/action-setup@v4
         id: pnpm-install
         with:
-          version: 8
           run_install: false
 
       # Get pnpm store directory

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "siyuan-plugins-mcp-sisyphus",
   "version": "0.6.1",
+  "packageManager": "pnpm@9.15.9",
   "type": "module",
   "description": "Let AI control your notes with a SiYuan MCP server that exposes 14 aggregated tools with action-level routing, including document timeline diff and official plugin tool bridging.",
   "repository": "https://github.com/yangtaihong59/siyuan-plugins-mcp-sisyphus",


### PR DESCRIPTION
## 为什么要改

现在仓库打正式版会失败。原因很简单：项目已经使用 pnpm 9 的锁文件，发布脚本却还在用 pnpm 8，导致依赖都装不上，编译和打包也就不会开始。

## 这个 PR 做了什么

把仓库统一到 pnpm 9.15.9，并让文档构建和正式发布共用同一处版本配置，避免以后两边再次不一致。

## 验证

依赖安装、1054 项测试、插件构建和 CLI 构建均已通过。

这项修改只修复构建和发布，不改变插件功能，也不接触思源数据。
