### PR TITLE
docs: 更新 0.6.1 的工具与测试清单

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,12 +11,12 @@
 1. **MCP Server 插件**：作为 SiYuan 插件运行，对外暴露 MCP（Model Context Protocol）服务。AI 客户端（Claude Desktop、Cursor、Cherry Studio 等）通过 HTTP 或 stdio 连接。
 2. **独立 CLI `siyuan-sisyphus`**：发布到 npm 的包名 `siyuan-sisyphus`，安装后提供 `siyuan-sisyphus` / `siyuan` 命令。直接通过思源 HTTP API 执行单次操作后退出，无需 MCP 客户端。
 
-两种接口共享同一套底层能力（10 个聚合工具、115+ 个 action），覆盖思源绝大部分功能：笔记本管理、文档操作、块级读写、属性视图（数据库）、搜索、标签、文件资源、闪卡、系统接口等。
+两种接口共享同一套底层能力（14 个聚合工具、121 个静态声明 action；`extension` 还可按官方注册表发现动态 action），覆盖思源绝大部分功能：笔记本管理、文档操作、块级读写、属性视图（数据库）、搜索、标签、文件资源、闪卡、系统接口等。
 
 - 仓库地址：`https://github.com/yangtaihong59/siyuan-plugins-mcp-sisyphus`
 - 作者：Taihong Yang
 - 许可证：MIT
-- 当前版本：`0.3.6`（根 `package.json` 与 `plugin.json` 同步）
+- 当前版本：`0.6.1`（根 `package.json` 与 `plugin.json` 同步）
 
 ---
 
@@ -65,7 +65,7 @@ siyuan-plugins-mcp-sisyphus/
 │   ├── core/                    # MCP 服务器核心与工具元数据
 │   │   ├── server.ts            # MCP Server 入口：createSiYuanServer()、startMcpServer()
 │   │   ├── http-transport.ts    # HTTP MCP 2026 无状态 + legacy 有会话双协议传输
-│   │   ├── tool-registry.ts     # TOOL_REGISTRY：10 个聚合工具的注册表
+│   │   ├── tool-registry.ts     # TOOL_REGISTRY：14 个聚合工具的注册表
 │   │   ├── tool-lifecycle.ts    # 工具调用生命周期：analytics、telemetry、token 计数、错误包装
 │   │   ├── config.ts            # ToolConfig 类型、默认值、配置迁移（扁平 → 嵌套）、危险动作定义
 │   │   ├── permissions.ts       # PermissionManager：笔记本级权限（rwd/rw/r/none）
@@ -80,7 +80,7 @@ siyuan-plugins-mcp-sisyphus/
 │   │   ├── server-instructions.ts # 服务端 instructions 文本构建
 │   │   └── runtime.ts           # 运行时环境检测（isPluginMode 等）
 │   │
-│   ├── tools/                   # 10 个聚合工具的实现
+│   ├── tools/                   # 14 个聚合工具的实现
 │   │   ├── index.ts             # barrel export：统一导出所有工具模块
 │   │   ├── internal/            # 工具层共享基础设施（非独立工具）
 │   │   │   ├── define-tool.ts   # defineTool() 工厂：统一工具定义模式
@@ -240,19 +240,23 @@ pnpm update-version     # 同步版本号到 plugin.json 与 cli/package.json
 
 ### 聚合工具模型（Aggregated Tools）
 
-所有思源能力被收敛为 **10 个聚合工具**，每个工具通过 `action` 字段路由到具体 operation：
+所有思源能力被收敛为 **14 个聚合工具**，每个工具通过 `action` 字段路由到具体 operation。以下是 `src/core/config.ts` 中的静态 action 计数；`extension` 的官方下游工具仍按运行时注册表动态发现：
 
 ```
+fs          → 8 actions（ls, tree, read, write, replace, rm, mv, search）
 notebook    → 11 actions（list, create, set_open_state, remove, rename, ...）
-document    → 17 actions（create, resolve, rename, remove, move, list_tree, ...）
-block       → 22 actions（insert, prepend, append, update, delete, move, ...）
-av          → 12 actions（get, render_attribute_view, add_rows, set_cells, ...）
-search      → 11 actions（fulltext, query_sql, get_backlinks, find_replace, ...）
-file        → 13 actions（upload_asset, export_md, list_unused_assets, ...）
-tag         → 3  actions（list, rename, remove）
-system      → 10 actions（get_version, push_msg, workspace_info, ...）
-flashcard   → 8  actions（list_cards, review_card, create_card, ...）
-mascot      → 3  actions（get_balance, shop, buy）
+document    → 16 actions（create, lookup, rename, remove, move, list_tree, ...）
+block       → 21 actions（insert, prepend, append, update, delete, move, ...）
+av          → 12 actions（get, render, add_rows, set_cells, ...）
+file        → 17 actions（upload_asset, export_md, list_unused_assets, ...）
+search      → 8 actions（fulltext, query_sql, get_backlinks, find_replace, ...）
+tag         → 3 actions（list, rename, remove）
+timeline    → 6 actions（list_nodes, create_node, compare_node, ...）
+system      → 8 actions（get_version, notify, workspace_info, ...）
+flashcard   → 6 actions（list_cards, get_decks, get_cards, ...）
+extension   → 1 static action（`list`）+ dynamic official tools
+mascot      → 3 actions（get_balance, shop, buy）
+feedback    → 1 action（submit）
 ```
 
 **约定**：不要拆散这个模型。每个 action 不是独立工具，而是聚合工具的参数分支。这降低了 MCP 的上下文占用，也保持了 CLI 命令的一致性。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
 1. **MCP Server 插件**：作为 SiYuan 插件运行，对外暴露 MCP（Model Context Protocol）服务。AI 客户端（Claude Desktop、Cursor、Cherry Studio 等）通过 HTTP 或 stdio 连接。
 2. **独立 CLI `siyuan-sisyphus`**：发布到 npm 的包名 `siyuan-sisyphus`，安装后提供 `siyuan-sisyphus` / `siyuan` 命令。直接通过思源 HTTP API 执行单次操作后退出，无需 MCP 客户端。
 
-两种接口共享同一套底层能力（14 个聚合工具、121 个静态声明 action；`extension` 还可按官方注册表发现动态 action），覆盖思源绝大部分功能：笔记本管理、文档操作、块级读写、属性视图（数据库）、搜索、标签、文件资源、闪卡、系统接口等。
+两种接口共享同一套底层能力，覆盖思源绝大部分功能：笔记本管理、文档操作、块级读写、属性视图（数据库）、搜索、标签、文件资源、闪卡、系统接口等。聚合工具类别和静态 action 清单以 `src/core/config.ts` 的 `TOOL_CATEGORIES` 与 `ACTIONS_BY_CATEGORY` 为唯一事实来源；`extension` 还可按官方注册表发现动态 action。
 
 - 仓库地址：`https://github.com/yangtaihong59/siyuan-plugins-mcp-sisyphus`
 - 作者：Taihong Yang
@@ -65,7 +65,7 @@ siyuan-plugins-mcp-sisyphus/
 │   ├── core/                    # MCP 服务器核心与工具元数据
 │   │   ├── server.ts            # MCP Server 入口：createSiYuanServer()、startMcpServer()
 │   │   ├── http-transport.ts    # HTTP MCP 2026 无状态 + legacy 有会话双协议传输
-│   │   ├── tool-registry.ts     # TOOL_REGISTRY：14 个聚合工具的注册表
+│   │   ├── tool-registry.ts     # TOOL_REGISTRY：聚合工具注册表
 │   │   ├── tool-lifecycle.ts    # 工具调用生命周期：analytics、telemetry、token 计数、错误包装
 │   │   ├── config.ts            # ToolConfig 类型、默认值、配置迁移（扁平 → 嵌套）、危险动作定义
 │   │   ├── permissions.ts       # PermissionManager：笔记本级权限（rwd/rw/r/none）
@@ -80,7 +80,7 @@ siyuan-plugins-mcp-sisyphus/
 │   │   ├── server-instructions.ts # 服务端 instructions 文本构建
 │   │   └── runtime.ts           # 运行时环境检测（isPluginMode 等）
 │   │
-│   ├── tools/                   # 14 个聚合工具的实现
+│   ├── tools/                   # 聚合工具的实现
 │   │   ├── index.ts             # barrel export：统一导出所有工具模块
 │   │   ├── internal/            # 工具层共享基础设施（非独立工具）
 │   │   │   ├── define-tool.ts   # defineTool() 工厂：统一工具定义模式
@@ -240,24 +240,9 @@ pnpm update-version     # 同步版本号到 plugin.json 与 cli/package.json
 
 ### 聚合工具模型（Aggregated Tools）
 
-所有思源能力被收敛为 **14 个聚合工具**，每个工具通过 `action` 字段路由到具体 operation。以下是 `src/core/config.ts` 中的静态 action 计数；`extension` 的官方下游工具仍按运行时注册表动态发现：
+所有思源能力被收敛为聚合工具，每个工具通过 `action` 字段路由到具体 operation。`src/core/config.ts` 中的 `TOOL_CATEGORIES` 定义类别顺序，`ACTIONS_BY_CATEGORY` 定义每类静态 action；要查看或更新清单，直接以这两个导出为准。`extension` 的官方下游工具仍按运行时注册表动态发现。
 
-```
-fs          → 8 actions（ls, tree, read, write, replace, rm, mv, search）
-notebook    → 11 actions（list, create, set_open_state, remove, rename, ...）
-document    → 16 actions（create, lookup, rename, remove, move, list_tree, ...）
-block       → 21 actions（insert, prepend, append, update, delete, move, ...）
-av          → 12 actions（get, render, add_rows, set_cells, ...）
-file        → 17 actions（upload_asset, export_md, list_unused_assets, ...）
-search      → 8 actions（fulltext, query_sql, get_backlinks, find_replace, ...）
-tag         → 3 actions（list, rename, remove）
-timeline    → 6 actions（list_nodes, create_node, compare_node, ...）
-system      → 8 actions（get_version, notify, workspace_info, ...）
-flashcard   → 6 actions（list_cards, get_decks, get_cards, ...）
-extension   → 1 static action（`list`）+ dynamic official tools
-mascot      → 3 actions（get_balance, shop, buy）
-feedback    → 1 action（submit）
-```
+静态清单由单元测试从这两个导出计算，避免文档在独立 action PR 合并后保留过期计数。
 
 **约定**：不要拆散这个模型。每个 action 不是独立工具，而是聚合工具的参数分支。这降低了 MCP 的上下文占用，也保持了 CLI 命令的一致性。
 

--- a/docs/architecture/modules.md
+++ b/docs/architecture/modules.md
@@ -157,7 +157,7 @@ src/
 
 ## 2. MCP Server: `src/core/server.ts`
 
-**Responsibility**: Create MCP `Server` instance, register 5 handlers, manage transport modes (stdio / HTTP), load config & permissions.
+**Responsibility**: Create MCP `Server` instance, register 7 handlers, manage transport modes (stdio / HTTP), load config & permissions. When the Skills extension is enabled, two additional conditional handlers are registered.
 
 **Key functions**:
 
@@ -167,7 +167,7 @@ src/
 | `startMcpServer()` | Process entry. Parse transport mode, start stdio or HTTP server |
 | `getToolConfig()` | Debounced ToolConfig hot-loading, in-flight deduplication |
 
-**5 registered handlers**:
+**7 always-registered handlers**:
 
 | Handler | Protocol Schema | Behavior |
 |---------|-----------------|----------|
@@ -175,7 +175,11 @@ src/
 | `ListResourcesRequestSchema` | Static resource list | `listHelpResources()` |
 | `ListResourceTemplatesRequestSchema` | Resource templates | `listHelpResourceTemplates()` (`siyuan://help/action/{tool}/{action}`) |
 | `ReadResourceRequestSchema` | Read resource | `readHelpResource(uri)` → static content or dynamic action help |
+| `PromptsListRequestSchema` | Prompt list | `listMcpPrompts()` |
+| `PromptsGetRequestSchema` | Prompt lookup | `getMcpPrompt(name, task)` |
 | `CallToolRequestSchema` | Call tool | Parse name + action → `resolveCategory()` → check enabled → `runToolCall()` → `TOOL_REGISTRY[category].callTool()` |
+
+With `SIYUAN_MCP_SKILLS_EXTENSION` enabled (the default), `skills/list` and `skills/get` add two conditional Skills-extension handlers.
 
 **Dependencies**: `http-transport.ts`, `tool-registry.ts`, `tool-lifecycle.ts`, `permissions.ts`, `config.ts`, `resources.ts`, `server-instructions.ts`
 
@@ -183,7 +187,7 @@ src/
 
 ## 3. Tool Registry: `src/core/tool-registry.ts`
 
-**Responsibility**: Maintain the `TOOL_REGISTRY` mapping table, converging 13 categories into the `ToolModule` interface. Category modules are registered at compile time; `extension` discovers its action set during the optional prepare phase.
+**Responsibility**: Maintain the `TOOL_REGISTRY` mapping table, converging 14 categories into the `ToolModule` interface. Category modules are registered at compile time; `extension` discovers its action set during the optional prepare phase.
 
 **Key interface**:
 
@@ -291,7 +295,7 @@ runToolCall(ctx, handler)
 type ToolConfig = {
     notebook:  { enabled: boolean, actions: { list: boolean, create: boolean, ... } };
     document:  { enabled: boolean, actions: { ... } };
-    // ... 13 categories total
+    // ... 14 categories total
     file:      { enabled: boolean, actions: { ... }, uploadLargeFileThresholdMB: number };
     // ...
     userRulesText: string;  // User custom rules text
@@ -468,7 +472,7 @@ All business modules export **pure functions** taking `client: SiYuanClient` as 
 
 ### `tool-config.ts` — Schema Definition
 
-Defines 13 `ToolCategory` entries, each with `enabled` + `actions` + extra fields (e.g. `file`'s `uploadLargeFileThresholdMB`, or `extension`'s `includeNativeTools` and `blockedTools`).
+Defines 14 `ToolCategory` entries, each with `enabled` + `actions` + extra fields (e.g. `file`'s `uploadLargeFileThresholdMB`, or `extension`'s `includeNativeTools` and `blockedTools`).
 
 ### `tool-config-storage.ts` — Persistence Layer
 
@@ -490,7 +494,7 @@ All `load*` functions perform defensive `normalize*` conversion.
 | Component | Responsibility |
 |-----------|---------------|
 | `HttpServerPanel` | HTTP/HTTPS toggle, host/port/token/TLS, client config snippet generation, real-time status & logs |
-| `ToolCategoriesPanel` | 9 tool category checkboxes + Notebook permission matrix (`none/r/rw/rwd`) |
+| `ToolCategoriesPanel` | 14 tool category checkboxes + Notebook permission matrix (`none/r/rw/rwd`) |
 | `PuppyPanel` | Mascot toggle + visibility/bubble/click hint/test mode |
 | `TelemetryPanel` | Telemetry toggle/interval/endpoint; local analytics dashboard (total calls, tokens, error rate, Top Actions, Daily Trend) |
 | `UserRulesPanel` | User custom rules text area |
@@ -504,7 +508,7 @@ All `load*` functions perform defensive `normalize*` conversion.
 | Component/File | Responsibility |
 |----------------|---------------|
 | `ToolPuppy.svelte` | **Core container**. Manages state machine (idle/reading/writing/deleting/moving/dangerous/success/error), polls event files, drag logic, idle animation scheduling |
-| `PuppyAwakeSVG.svelte` | Awake pixel cat SVG (52×52). Body, tail, paws, multiple eye expressions, 9 tool icons + action markers, wage card balance display |
+| `PuppyAwakeSVG.svelte` | Awake pixel cat SVG (52×52). Body, tail, paws, multiple eye expressions, 8 tool icons + action markers, wage card balance display |
 | `PuppySleepingSVG.svelte` | Sleep state overlay: floating "zZz" animation |
 | `PuppyBubble.svelte` | Bubble & effects layer: text bubbles, wage card bubbles, heart bursts (`❤`), feeding props |
 | `PuppyResultOverlay.svelte` | Result/danger state SVG overlay: red X, exclamation mark, error badge |

--- a/docs/architecture/modules.md
+++ b/docs/architecture/modules.md
@@ -14,7 +14,7 @@ src/
 ├── core/                     # MCP Server core
 │   ├── server.ts             # MCP Server creation & handler registration
 │   ├── http-transport.ts     # HTTP/S MCP transport layer
-│   ├── tool-registry.ts      # Registry of 14 aggregated tools, including dynamic extension actions
+│   ├── tool-registry.ts      # Registry of aggregated tools, including dynamic extension actions
 │   ├── tool-lifecycle.ts     # Tool call AOP wrapper (analytics/telemetry/puppy)
 │   ├── permissions.ts        # Notebook-level 4-tier permission management
 │   ├── config.ts             # ToolConfig schema / defaults / migration
@@ -32,7 +32,7 @@ src/
 │   ├── normalize.ts          # Request parameter normalization
 │   └── noops/                # Explicit no-op schema validator for SDK v2
 │       └── noop-schema-validator.ts
-├── tools/                    # 14 aggregated tool implementations
+├── tools/                    # Aggregated tool implementations
 │   ├── index.ts              # Barrel export: re-exports all tool modules
 │   ├── internal/             # Shared infrastructure for the tool layer
 │   │   ├── types.ts          # Shared types for the tool layer
@@ -187,7 +187,7 @@ With `SIYUAN_MCP_SKILLS_EXTENSION` enabled (the default), `skills/list` and `ski
 
 ## 3. Tool Registry: `src/core/tool-registry.ts`
 
-**Responsibility**: Maintain the `TOOL_REGISTRY` mapping table, converging 14 categories into the `ToolModule` interface. Category modules are registered at compile time; `extension` discovers its action set during the optional prepare phase.
+**Responsibility**: Maintain the `TOOL_REGISTRY` mapping table, converging the categories declared by `TOOL_CATEGORIES` into the `ToolModule` interface. Category modules are registered at compile time; `extension` discovers its action set during the optional prepare phase.
 
 **Key interface**:
 
@@ -204,7 +204,7 @@ interface ToolModule {
 
 | Export | Description |
 |--------|-------------|
-| `TOOL_REGISTRY: Record<ToolCategory, ToolModule>` | Compile-time mapping of 14 aggregated categories |
+| `TOOL_REGISTRY: Record<ToolCategory, ToolModule>` | Compile-time mapping of the aggregated categories declared by `TOOL_CATEGORIES` |
 | `prepareAllTools(config, runtime)` | Run optional discovery/prepare hooks before dynamic validation or listing |
 | `listAllTools(config, runtime)` | Flatten and aggregate all enabled tool descriptors |
 | `resolveCategory(name)` | Reverse lookup category from tool name (e.g. `"notebook"`) |
@@ -295,7 +295,7 @@ runToolCall(ctx, handler)
 type ToolConfig = {
     notebook:  { enabled: boolean, actions: { list: boolean, create: boolean, ... } };
     document:  { enabled: boolean, actions: { ... } };
-    // ... 14 categories total
+    // ... categories declared by TOOL_CATEGORIES
     file:      { enabled: boolean, actions: { ... }, uploadLargeFileThresholdMB: number };
     // ...
     userRulesText: string;  // User custom rules text
@@ -472,7 +472,7 @@ All business modules export **pure functions** taking `client: SiYuanClient` as 
 
 ### `tool-config.ts` — Schema Definition
 
-Defines 14 `ToolCategory` entries, each with `enabled` + `actions` + extra fields (e.g. `file`'s `uploadLargeFileThresholdMB`, or `extension`'s `includeNativeTools` and `blockedTools`).
+Defines the `ToolCategory` entries in `TOOL_CATEGORIES`, each with `enabled` + `actions` + extra fields (e.g. `file`'s `uploadLargeFileThresholdMB`, or `extension`'s `includeNativeTools` and `blockedTools`).
 
 ### `tool-config-storage.ts` — Persistence Layer
 
@@ -494,7 +494,7 @@ All `load*` functions perform defensive `normalize*` conversion.
 | Component | Responsibility |
 |-----------|---------------|
 | `HttpServerPanel` | HTTP/HTTPS toggle, host/port/token/TLS, client config snippet generation, real-time status & logs |
-| `ToolCategoriesPanel` | 14 tool category checkboxes + Notebook permission matrix (`none/r/rw/rwd`) |
+| `ToolCategoriesPanel` | Tool category checkboxes + Notebook permission matrix (`none/r/rw/rwd`) |
 | `PuppyPanel` | Mascot toggle + visibility/bubble/click hint/test mode |
 | `TelemetryPanel` | Telemetry toggle/interval/endpoint; local analytics dashboard (total calls, tokens, error rate, Top Actions, Daily Trend) |
 | `UserRulesPanel` | User custom rules text area |

--- a/docs/testing/ACTION_TEST_COVERAGE.md
+++ b/docs/testing/ACTION_TEST_COVERAGE.md
@@ -1,29 +1,29 @@
 # Action Test Coverage
 
-本文档记录当前源码中 14 个聚合工具 action 的自动化测试覆盖口径。它补充 `AI_INTERFACE_TEST.md` 的人工/真实思源回归流程，重点回答一个问题：
+本文档记录当前源码中聚合工具 action 的自动化测试覆盖口径。它补充 `AI_INTERFACE_TEST.md` 的人工/真实思源回归流程，重点回答一个问题：
 
 > 每个已声明 action 是否至少有一条自动化测试能跑到运行时调用路径？
 
 ## 覆盖结论
 
-截至当前代码，源码中声明的静态 action 总数为 121 个；`extension` 还会按官方注册表生成动态 action。
+静态 action 总数和每个工具的 action 清单从 `src/core/config.ts` 的 `ACTIONS_BY_CATEGORY` 计算；`extension` 还会按官方注册表生成动态 action。`tests/unit/core/action-inventory-docs.test.ts` 会确认类别和静态 action 均由该注册表导出，因此新增 action 不需要手工改写本页的计数。
 
-| 工具 | action 数 | 覆盖方式 |
+| 工具 | action 清单来源 | 覆盖方式 |
 | --- | ---: | --- |
-| `fs` | 8 | `tests/unit/tools/action-contract.test.ts` 对每个 action 做最小运行时契约调用 |
-| `notebook` | 11 | `tests/unit/tools/action-contract.test.ts` 对每个 action 做最小运行时契约调用 |
-| `document` | 16 | `tests/unit/tools/action-contract.test.ts` 对每个 action 做最小运行时契约调用 |
-| `block` | 21 | `tests/unit/tools/action-contract.test.ts` 对每个 action 做最小运行时契约调用 |
-| `av` | 12 | `tests/unit/tools/av.test.ts` 对每个 action 有直接调用覆盖 |
-| `search` | 8 | `tests/unit/tools/action-contract.test.ts` 对每个 action 做最小运行时契约调用 |
-| `file` | 17 | `tests/unit/tools/action-contract.test.ts` 对每个 action 做最小运行时契约调用 |
-| `system` | 8 | `tests/unit/tools/action-contract.test.ts` 对每个 action 做最小运行时契约调用 |
-| `flashcard` | 6 | `tests/unit/tools/flashcard.test.ts` 对每个 action 有直接调用覆盖 |
-| `extension` | 1 + 动态 | `tests/unit/core/official-mcp-bridge.test.ts` 与 `tests/unit/tools/extension.test.ts` 覆盖发现、schema、屏蔽和转发 |
-| `tag` | 3 | `tests/unit/tools/action-contract.test.ts` 对每个 action 做最小运行时契约调用 |
-| `timeline` | 6 | `tests/unit/tools/timeline.test.ts` 覆盖默认开关、节点创建/删除、diff、块回档与 `rwd` 权限 |
-| `mascot` | 3 | `tests/unit/tools/mascot.test.ts` 对每个 action 有直接调用覆盖 |
-| `feedback` | 1 | `tests/unit/core/feedback.test.ts` 和 `tests/unit/tools/feedback.test.ts` 覆盖 WPS payload 与工具路由 |
+| `fs` | `ACTIONS_BY_CATEGORY.fs` | `tests/unit/tools/action-contract.test.ts` 对每个 action 做最小运行时契约调用 |
+| `notebook` | `ACTIONS_BY_CATEGORY.notebook` | `tests/unit/tools/action-contract.test.ts` 对每个 action 做最小运行时契约调用 |
+| `document` | `ACTIONS_BY_CATEGORY.document` | `tests/unit/tools/action-contract.test.ts` 对每个 action 做最小运行时契约调用 |
+| `block` | `ACTIONS_BY_CATEGORY.block` | `tests/unit/tools/action-contract.test.ts` 对每个 action 做最小运行时契约调用 |
+| `av` | `ACTIONS_BY_CATEGORY.av` | `tests/unit/tools/av.test.ts` 对每个 action 有直接调用覆盖 |
+| `search` | `ACTIONS_BY_CATEGORY.search` | `tests/unit/tools/action-contract.test.ts` 对每个 action 做最小运行时契约调用 |
+| `file` | `ACTIONS_BY_CATEGORY.file` | `tests/unit/tools/action-contract.test.ts` 对每个 action 做最小运行时契约调用 |
+| `system` | `ACTIONS_BY_CATEGORY.system` | `tests/unit/tools/action-contract.test.ts` 对每个 action 做最小运行时契约调用 |
+| `flashcard` | `ACTIONS_BY_CATEGORY.flashcard` | `tests/unit/tools/flashcard.test.ts` 对每个 action 有直接调用覆盖 |
+| `extension` | `ACTIONS_BY_CATEGORY.extension` + 动态官方注册表 | `tests/unit/core/official-mcp-bridge.test.ts` 与 `tests/unit/tools/extension.test.ts` 覆盖发现、schema、屏蔽和转发 |
+| `tag` | `ACTIONS_BY_CATEGORY.tag` | `tests/unit/tools/action-contract.test.ts` 对每个 action 做最小运行时契约调用 |
+| `timeline` | `ACTIONS_BY_CATEGORY.timeline` | `tests/unit/tools/timeline.test.ts` 覆盖默认开关、节点创建/删除、diff、块回档与 `rwd` 权限 |
+| `mascot` | `ACTIONS_BY_CATEGORY.mascot` | `tests/unit/tools/mascot.test.ts` 对每个 action 有直接调用覆盖 |
+| `feedback` | `ACTIONS_BY_CATEGORY.feedback` | `tests/unit/core/feedback.test.ts` 和 `tests/unit/tools/feedback.test.ts` 覆盖 WPS payload 与工具路由 |
 
 ## 契约测试规则
 
@@ -40,6 +40,7 @@
 
 ```bash
 pnpm vitest run tests/unit/tools/action-contract.test.ts
+pnpm vitest run tests/unit/core/action-inventory-docs.test.ts
 pnpm vitest run tests/unit/tools
 ```
 

--- a/docs/testing/ACTION_TEST_COVERAGE.md
+++ b/docs/testing/ACTION_TEST_COVERAGE.md
@@ -6,14 +6,14 @@
 
 ## 覆盖结论
 
-截至当前代码，源码中声明的静态 action 总数为 119 个；`extension` 还会按官方注册表生成动态 action。
+截至当前代码，源码中声明的静态 action 总数为 121 个；`extension` 还会按官方注册表生成动态 action。
 
 | 工具 | action 数 | 覆盖方式 |
 | --- | ---: | --- |
 | `fs` | 8 | `tests/unit/tools/action-contract.test.ts` 对每个 action 做最小运行时契约调用 |
 | `notebook` | 11 | `tests/unit/tools/action-contract.test.ts` 对每个 action 做最小运行时契约调用 |
-| `document` | 15 | `tests/unit/tools/action-contract.test.ts` 对每个 action 做最小运行时契约调用 |
-| `block` | 20 | `tests/unit/tools/action-contract.test.ts` 对每个 action 做最小运行时契约调用 |
+| `document` | 16 | `tests/unit/tools/action-contract.test.ts` 对每个 action 做最小运行时契约调用 |
+| `block` | 21 | `tests/unit/tools/action-contract.test.ts` 对每个 action 做最小运行时契约调用 |
 | `av` | 12 | `tests/unit/tools/av.test.ts` 对每个 action 有直接调用覆盖 |
 | `search` | 8 | `tests/unit/tools/action-contract.test.ts` 对每个 action 做最小运行时契约调用 |
 | `file` | 17 | `tests/unit/tools/action-contract.test.ts` 对每个 action 做最小运行时契约调用 |

--- a/docs/zh/architecture/modules.md
+++ b/docs/zh/architecture/modules.md
@@ -157,7 +157,7 @@ src/
 
 ## 2. MCP Server：`src/core/server.ts`
 
-**职责**：创建 MCP `Server` 实例，注册 5 个 handler，管理 transport 模式（stdio / HTTP），加载配置与权限。
+**职责**：创建 MCP `Server` 实例，注册 7 个 handler，管理 transport 模式（stdio / HTTP），加载配置与权限。启用 Skills 扩展时，还会额外注册 2 个条件 handler。
 
 **关键函数**：
 
@@ -167,7 +167,7 @@ src/
 | `startMcpServer()` | 进程入口。解析 transport mode，启动 stdio 或 HTTP server |
 | `getToolConfig()` | 带防抖的 ToolConfig 热加载，in-flight 去重 |
 
-**注册的 5 个 Handler**：
+**始终注册的 7 个 Handler**：
 
 | Handler | 协议 Schema | 行为 |
 |---------|-------------|------|
@@ -175,7 +175,11 @@ src/
 | `ListResourcesRequestSchema` | 静态资源列表 | `listHelpResources()` |
 | `ListResourceTemplatesRequestSchema` | 资源模板 | `listHelpResourceTemplates()`（`siyuan://help/action/{tool}/{action}`） |
 | `ReadResourceRequestSchema` | 读资源 | `readHelpResource(uri)` → 静态内容或动态 action help |
+| `PromptsListRequestSchema` | Prompt 列表 | `listMcpPrompts()` |
+| `PromptsGetRequestSchema` | Prompt 查询 | `getMcpPrompt(name, task)` |
 | `CallToolRequestSchema` | 调用工具 | 解析 name + action → `resolveCategory()` → 检查 enabled → `runToolCall()` → `TOOL_REGISTRY[category].callTool()` |
+
+启用 `SIYUAN_MCP_SKILLS_EXTENSION`（默认启用）时，`skills/list` 和 `skills/get` 还会额外注册两个条件 Skills 扩展 handler。
 
 **依赖**：`http-transport.ts`、`tool-registry.ts`、`tool-lifecycle.ts`、`permissions.ts`、`config.ts`、`resources.ts`、`server-instructions.ts`
 
@@ -183,7 +187,7 @@ src/
 
 ## 3. 工具注册表：`src/core/tool-registry.ts`
 
-**职责**：维护 `TOOL_REGISTRY` 映射表，将 13 个 category 统一收敛为 `ToolModule` 接口。category 模块在编译期注册，`extension` 在可选的 prepare 阶段动态发现 action 集合。
+**职责**：维护 `TOOL_REGISTRY` 映射表，将 14 个 category 统一收敛为 `ToolModule` 接口。category 模块在编译期注册，`extension` 在可选的 prepare 阶段动态发现 action 集合。
 
 **关键接口**：
 
@@ -291,7 +295,7 @@ runToolCall(ctx, handler)
 type ToolConfig = {
     notebook:  { enabled: boolean, actions: { list: boolean, create: boolean, ... } };
     document:  { enabled: boolean, actions: { ... } };
-    // ... 共 13 个 category
+    // ... 共 14 个 category
     file:      { enabled: boolean, actions: { ... }, uploadLargeFileThresholdMB: number };
     // ...
     userRulesText: string;  // 用户自定义规则文本
@@ -468,7 +472,7 @@ CLI flag (--url / --token)
 
 ### `tool-config.ts` — Schema 定义
 
-定义 13 个 `ToolCategory`，每个含 `enabled` + `actions` + 额外字段（如 `file` 的 `uploadLargeFileThresholdMB`、`extension` 的 `includeNativeTools` 与 `blockedTools`）。
+定义 14 个 `ToolCategory`，每个含 `enabled` + `actions` + 额外字段（如 `file` 的 `uploadLargeFileThresholdMB`、`extension` 的 `includeNativeTools` 与 `blockedTools`）。
 
 ### `tool-config-storage.ts` — 持久化层
 
@@ -490,7 +494,7 @@ CLI flag (--url / --token)
 | 组件 | 职责 |
 |------|------|
 | `HttpServerPanel` | HTTP/HTTPS 开关、host/port/token/TLS、客户端配置片段生成、实时状态与日志 |
-| `ToolCategoriesPanel` | 9 大工具分类的 checkbox + Notebook 权限矩阵（`none/r/rw/rwd`） |
+| `ToolCategoriesPanel` | 14 大工具分类的 checkbox + Notebook 权限矩阵（`none/r/rw/rwd`） |
 | `PuppyPanel` | 吉祥物开关 + 可见性/气泡/点击提示/测试模式 |
 | `TelemetryPanel` | 遥测开关/间隔/endpoint；本地分析看板（总调用数、token、错误率、Top Actions、Daily Trend） |
 | `UserRulesPanel` | 用户自定义规则文本域 |
@@ -504,7 +508,7 @@ CLI flag (--url / --token)
 | 组件/文件 | 职责 |
 |-----------|------|
 | `ToolPuppy.svelte` | **核心容器**。管理状态机（idle/reading/writing/deleting/moving/dangerous/success/error）、轮询事件文件、拖拽逻辑、空闲动画调度 |
-| `PuppyAwakeSVG.svelte` | 清醒状态像素猫 SVG（52×52）。含猫身、尾巴、爪子、多组眼睛表情、9 种工具图标、工资卡余额显示 |
+| `PuppyAwakeSVG.svelte` | 清醒状态像素猫 SVG（52×52）。含猫身、尾巴、爪子、多组眼睛表情、8 种工具图标、工资卡余额显示 |
 | `PuppySleepingSVG.svelte` | 睡眠状态叠加层：飘出的 "zZz" 动画 |
 | `PuppyBubble.svelte` | 气泡与特效层：文字气泡、工资卡气泡、爱心爆发、喂食道具 |
 | `PuppyResultOverlay.svelte` | 结果/危险状态 SVG 叠加：红叉、感叹号、错误角标 |

--- a/docs/zh/architecture/modules.md
+++ b/docs/zh/architecture/modules.md
@@ -14,7 +14,7 @@ src/
 ├── core/                     # MCP Server 核心
 │   ├── server.ts             # MCP Server 创建与 Handler 注册
 │   ├── http-transport.ts     # HTTP/S MCP 传输层
-│   ├── tool-registry.ts      # 14 个聚合工具注册表，包含动态 extension action
+│   ├── tool-registry.ts      # 聚合工具注册表，包含动态 extension action
 │   ├── tool-lifecycle.ts     # 工具调用 AOP 切面（analytics/telemetry/puppy）
 │   ├── permissions.ts        # 笔记本级四级权限管理
 │   ├── config.ts             # ToolConfig schema / 默认值 / 迁移
@@ -32,7 +32,7 @@ src/
 │   ├── normalize.ts          # 请求参数归一化
 │   └── noops/                # SDK v2 显式 no-op schema validator
 │       └── noop-schema-validator.ts
-├── tools/                    # 14 个聚合工具的实现
+├── tools/                    # 聚合工具的实现
 │   ├── index.ts              # Barrel export：统一导出所有工具
 │   ├── internal/             # 工具层共享基础设施
 │   │   ├── types.ts          # 工具层共享类型
@@ -187,7 +187,7 @@ src/
 
 ## 3. 工具注册表：`src/core/tool-registry.ts`
 
-**职责**：维护 `TOOL_REGISTRY` 映射表，将 14 个 category 统一收敛为 `ToolModule` 接口。category 模块在编译期注册，`extension` 在可选的 prepare 阶段动态发现 action 集合。
+**职责**：维护 `TOOL_REGISTRY` 映射表，将 `TOOL_CATEGORIES` 声明的 category 统一收敛为 `ToolModule` 接口。category 模块在编译期注册，`extension` 在可选的 prepare 阶段动态发现 action 集合。
 
 **关键接口**：
 
@@ -204,7 +204,7 @@ interface ToolModule {
 
 | 导出 | 说明 |
 |------|------|
-| `TOOL_REGISTRY: Record<ToolCategory, ToolModule>` | 14 个聚合 category 的编译期映射 |
+| `TOOL_REGISTRY: Record<ToolCategory, ToolModule>` | `TOOL_CATEGORIES` 声明的聚合 category 编译期映射 |
 | `prepareAllTools(config, runtime)` | 在动态校验或列举前执行可选的发现/准备钩子 |
 | `listAllTools(config, runtime)` | 扁平化聚合所有启用状态下的 tool descriptor |
 | `resolveCategory(name)` | 从 tool name（如 `"notebook"`）反查 category |
@@ -295,7 +295,7 @@ runToolCall(ctx, handler)
 type ToolConfig = {
     notebook:  { enabled: boolean, actions: { list: boolean, create: boolean, ... } };
     document:  { enabled: boolean, actions: { ... } };
-    // ... 共 14 个 category
+    // ... 以 TOOL_CATEGORIES 声明的 category 为准
     file:      { enabled: boolean, actions: { ... }, uploadLargeFileThresholdMB: number };
     // ...
     userRulesText: string;  // 用户自定义规则文本
@@ -472,7 +472,7 @@ CLI flag (--url / --token)
 
 ### `tool-config.ts` — Schema 定义
 
-定义 14 个 `ToolCategory`，每个含 `enabled` + `actions` + 额外字段（如 `file` 的 `uploadLargeFileThresholdMB`、`extension` 的 `includeNativeTools` 与 `blockedTools`）。
+定义 `TOOL_CATEGORIES` 中的 `ToolCategory`，每个含 `enabled` + `actions` + 额外字段（如 `file` 的 `uploadLargeFileThresholdMB`、`extension` 的 `includeNativeTools` 与 `blockedTools`）。
 
 ### `tool-config-storage.ts` — 持久化层
 
@@ -494,7 +494,7 @@ CLI flag (--url / --token)
 | 组件 | 职责 |
 |------|------|
 | `HttpServerPanel` | HTTP/HTTPS 开关、host/port/token/TLS、客户端配置片段生成、实时状态与日志 |
-| `ToolCategoriesPanel` | 14 大工具分类的 checkbox + Notebook 权限矩阵（`none/r/rw/rwd`） |
+| `ToolCategoriesPanel` | 工具分类的 checkbox + Notebook 权限矩阵（`none/r/rw/rwd`） |
 | `PuppyPanel` | 吉祥物开关 + 可见性/气泡/点击提示/测试模式 |
 | `TelemetryPanel` | 遥测开关/间隔/endpoint；本地分析看板（总调用数、token、错误率、Top Actions、Daily Trend） |
 | `UserRulesPanel` | 用户自定义规则文本域 |

--- a/tests/unit/core/action-inventory-docs.test.ts
+++ b/tests/unit/core/action-inventory-docs.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+import { ACTIONS_BY_CATEGORY, TOOL_CATEGORIES } from '@/core/config';
+import { TOOL_REGISTRY } from '@/core/tool-registry';
+
+describe('action inventory documentation contract', () => {
+    it('derives every static category and action count from the source registry', () => {
+        const categories = Object.keys(ACTIONS_BY_CATEGORY);
+        const staticActionTotal = Object.values(ACTIONS_BY_CATEGORY)
+            .reduce((total, actions) => total + actions.length, 0);
+        const coverageDoc = readFileSync(
+            new URL('../../../docs/testing/ACTION_TEST_COVERAGE.md', import.meta.url),
+            'utf8',
+        );
+
+        expect(categories).toEqual([...TOOL_CATEGORIES]);
+        expect(Object.keys(TOOL_REGISTRY).sort()).toEqual([...TOOL_CATEGORIES].sort());
+        expect(staticActionTotal).toBeGreaterThan(0);
+        expect(coverageDoc).toContain('`ACTIONS_BY_CATEGORY`');
+        for (const category of TOOL_CATEGORIES) {
+            expect(coverageDoc).toContain(`ACTIONS_BY_CATEGORY.${category}`);
+        }
+    });
+});


### PR DESCRIPTION
## 为什么要改

#50 原先把 v0.6.1 的 action 总数和各分类数量写死在文档中。它在当前基线虽正确，但独立 action PR 合并后不会产生冲突，文档会静默过期；也不能提前把尚未进入 main 的功能计入当前版本。

## 做了什么

将四份维护文档中的类别和静态 action 计数改为指向 `src/core/config.ts` 的 `TOOL_CATEGORIES` 与 `ACTIONS_BY_CATEGORY`，并新增小型合同测试，确认文档列出的每个类别都由该注册表提供。这样当前文档只陈述已存在的源码事实，后续 action 变更也不必手工维护重复计数。

## 验证

`npm run skills:check` 通过；`pnpm exec vitest run tests/unit/core/action-inventory-docs.test.ts tests/unit/core/tool-registry.test.ts tests/unit/tools/action-contract.test.ts` 通过（3 files、13 tests）；`pnpm docs:build` 通过；`git diff --check` 通过。