### PR TITLE
修复条件写入的 CLI/MCP 严格字段声明

### DIFF
--- a/src/core/tool-registry.ts
+++ b/src/core/tool-registry.ts
@@ -4,7 +4,7 @@ import type { PermissionManager } from './permissions';
 import type { ToolResult } from '@/tools/internal/shared';
 import type { OfficialMcpRuntime, OfficialMcpDiscoverySnapshot } from './official-mcp-bridge';
 import { ACTION_SCHEMA_BRANCHES_KEY } from '@/tools/internal/shared';
-import { PRECONDITION_FIELD, getActionSafetyPolicy } from './write-safety-policy';
+import { PRECONDITION_FIELD, getPossibleActionSafetyPolicies } from './write-safety-policy';
 
 import {
     callAvTool,
@@ -225,17 +225,29 @@ function decorateStrictWriteSchema(category: ToolCategory, descriptor: ToolDescr
         const branches = originalBranches.map((branch) => {
             const action = branch?.properties?.action?.const;
             if (typeof action !== 'string' || action === 'help') return branch;
-            const policy = getActionSafetyPolicy(category, action);
-            if (policy.mode !== 'mutation') return branch;
+            // 某些 action 是否写入取决于参数（例如 createIfNotExist 或
+            // overwrite=true）。普通分支无法表达这个条件，因此必须把所有
+            // 可能写入路径需要的严格字段都放进分支；否则客户端拿到的合法
+            // 分支无法携带协调器运行时要求的 requestId/哈希凭据。
+            const policies = getPossibleActionSafetyPolicies(category, action);
+            const mutationPolicies = policies.filter((policy) => policy.mode === 'mutation');
+            if (mutationPolicies.length === 0) return branch;
             const branchProperties = {
                 ...(branch.properties ?? {}),
                 requestId: properties.requestId,
                 validateOnly: properties.validateOnly,
             };
-            if (policy.precondition !== 'none') {
-                const field = PRECONDITION_FIELD[policy.precondition];
-                branchProperties[field] = properties[field];
-                if (field === 'expectedStateHash') branchProperties.expectedHash = properties.expectedHash;
+            const preconditions = mutationPolicies
+                .map((policy) => policy.mode === 'mutation' ? policy.precondition : 'none')
+                .filter((precondition): precondition is keyof typeof PRECONDITION_FIELD => precondition !== 'none');
+            if (preconditions.length > 0) {
+                // 一个分支只有一张扁平 properties 表，所以保留条件写入
+                // 可能需要的每一种前置条件字段。
+                for (const precondition of new Set(preconditions)) {
+                    const field = PRECONDITION_FIELD[precondition];
+                    branchProperties[field] = properties[field];
+                    if (field === 'expectedStateHash') branchProperties.expectedHash = properties.expectedHash;
+                }
             }
             return { ...branch, properties: branchProperties };
         });

--- a/src/core/write-safety-policy.ts
+++ b/src/core/write-safety-policy.ts
@@ -122,6 +122,27 @@ export function getActionSafetyPolicy(
     return policy;
 }
 
+/**
+ * Return every safety policy reachable by an action's schema branch.
+ *
+ * A few actions switch between read and mutation based on arguments. The
+ * registry uses this helper to advertise the union of fields required by all
+ * runtime paths, keeping schema decoration and dispatch on one policy source.
+ */
+export function getPossibleActionSafetyPolicies(category: ToolCategory, action: string): ActionSafetyPolicy[] {
+    const policies = [getActionSafetyPolicy(category, action)];
+    if (category === 'fs' && action === 'write') {
+        policies.push(getActionSafetyPolicy(category, action, { overwrite: true }));
+    }
+    if (category === 'file' && action === 'create_template') {
+        policies.push(getActionSafetyPolicy(category, action, { overwrite: true }));
+    }
+    if (category === 'av' && action === 'render') {
+        policies.push(getActionSafetyPolicy(category, action, { createIfNotExist: true }));
+    }
+    return policies;
+}
+
 export function assertActionSafetyPoliciesComplete(): void {
     for (const [category, actions] of Object.entries(ACTIONS_BY_CATEGORY) as Array<[
         ToolCategory,

--- a/tests/unit/core/write-safety-policy.test.ts
+++ b/tests/unit/core/write-safety-policy.test.ts
@@ -44,7 +44,7 @@ describe('write safety action policy', () => {
         const strictBlock = listAllTools(strict).find((tool) => tool.name === 'block')!;
         expect(strictBlock.inputSchema.properties).toHaveProperty('requestId');
         expect(strictBlock.inputSchema.properties).toHaveProperty('expectedStateHash');
-        const credentialPattern = new RegExp(strictBlock.inputSchema.properties.expectedStateHash.pattern);
+        const credentialPattern = new RegExp((strictBlock.inputSchema.properties as any).expectedStateHash.pattern);
         expect(credentialPattern.test('sha256:v1:8ac2')).toBe(true);
         expect(credentialPattern.test('8AC2')).toBe(true);
         expect(credentialPattern.test('f'.repeat(64))).toBe(true);
@@ -55,5 +55,27 @@ describe('write safety action policy', () => {
         strict.writeSafety.strictMode = false;
         const legacyBlock = listAllTools(strict).find((tool) => tool.name === 'block')!;
         expect(legacyBlock.inputSchema.properties).not.toHaveProperty('requestId');
+    });
+
+    it('advertises strict fields on conditional mutation branches', () => {
+        const config = buildDefaultToolConfig();
+        const branchKey = 'x-sisyphus-actionSchemas';
+
+        for (const [category, action] of [
+            ['fs', 'write'],
+            ['file', 'create_template'],
+            ['av', 'render'],
+        ] as const) {
+            const descriptor = listAllTools(config).find((tool) => tool.name === category)!;
+            const branches = (descriptor.inputSchema as Record<string, unknown>)[branchKey] as Array<Record<string, any>>;
+            const branch = branches.find((entry) => entry.properties?.action?.const === action);
+
+            expect(branch, `${category}.${action} branch`).toBeDefined();
+            expect(branch?.properties).toHaveProperty('requestId');
+            expect(branch?.properties).toHaveProperty('validateOnly');
+            if (category === 'fs' || category === 'file') {
+                expect(branch?.properties).toHaveProperty('expectedStateHash');
+            }
+        }
     });
 });


### PR DESCRIPTION
## 为什么要改

严格安全写入的 action 分支 schema 之前只按默认参数判断是否需要严格字段，但 `fs.write(overwrite=true)`、`file.create_template(overwrite=true)` 和 `av.render(createIfNotExist=true)` 会在运行时进入 mutation。这样 MCP 客户端拿到的合法分支没有 `requestId` 与相应的 `expected*Hash` 字段，CLI 复用同一 inputSchema 时也会漏掉对应 flag/help。

## 做了什么

新增 `getPossibleActionSafetyPolicies`，组合现有 `getActionSafetyPolicy` 在不同参数下的结果，不复制 action registry 或 safety policy。严格 schema 现在为上述条件写入分支发布所有可能 mutation 路径需要的字段，CLI 与 MCP 继续共用同一权威 policy 和 schema。

补充了三项回归断言，分别覆盖 `fs.write`、`file.create_template` 和 `av.render` 的条件 mutation 分支。没有修改 `vite.config.ts`、stdio bundling 或 PR #47 相关文件。

## 验证

- `npm test`：94 个文件，1055 个测试通过。
- focused tests：tool registry、write-safety policy、action contracts、CLI dispatch/list-help，共 41 个测试通过。
- `npm run build:cli`：通过。
- `git diff --check`：通过。

本 PR 只提交代码和测试，不包含 live SiYuan mutation；全局 `tsc --noEmit` 的既存基线错误未由本改动引入。
