### PR TITLE
新增受限的链接目标解析与创建

### DIFF
--- a/API_COMPLETE_MAPPING.md
+++ b/API_COMPLETE_MAPPING.md
@@ -4,7 +4,7 @@
 - **SiYuan API 总数**: 459 个端点
 - **MCP Tools**: 10 个
 - **已覆盖 API**: 119 个端点
-- **已覆盖 MCP Actions**: 117 个
+- **已覆盖 MCP Actions**: 118 个
 - **未覆盖 API**: 340 个端点
 - **整体覆盖率**: 25.9%
 
@@ -37,7 +37,7 @@
 | 19 | POST | `/api/block/getBlocksWordCount` | getBlocksWordCount | 块获取s字数统计 | block.word_count | ✅ 已覆盖 |
 | 20 | POST | `/api/block/getContentWordCount` | getContentWordCount | 块获取Content字数统计 | - | ❌ 未覆盖 |
 | 21 | POST | `/api/block/getRecentUpdatedBlocks` | getRecentUpdatedBlocks | 块获取RecentUpdatedBlocks | block.recent_updated | ✅ 已覆盖 |
-| 22 | POST | `/api/block/getDocInfo` | getDocInfo | 块获取Doc信息 | block.doc_info | ✅ 已覆盖 |
+| 22 | POST | `/api/block/getDocInfo` | getDocInfo | 块获取Doc信息 | block.doc_info<br>document.ensure_link_targets | ✅ 已覆盖 |
 | 23 | POST | `/api/block/getDocsInfo` | getDocsInfo | 块获取Docs信息 | block.docs_info | ✅ 已覆盖 |
 | 24 | POST | `/api/block/checkBlockExist` | checkBlockExist | 块检查Exist | block.exists | ✅ 已覆盖 |
 | 25 | POST | `/api/block/getUnfoldedParentID` | getUnfoldedParentID | 块获取UnfoldedParentID | - | ❌ 未覆盖 |
@@ -179,12 +179,12 @@
 | 序号 | 方法 | API 路径 | 处理函数 | 功能描述 | MCP 映射 | 状态 |
 |------|------|----------|----------|----------|----------|------|
 | 1 | POST | `/api/filetree/searchDocs` | searchDocs | 文档树搜索s | document.search_docs | ✅ 已覆盖 |
-| 2 | POST | `/api/filetree/listDocsByPath` | listDocsByPath | 文档树列出sBy路径 | notebook.get_child_docs<br>document.get_child_docs | ✅ 已覆盖 |
+| 2 | POST | `/api/filetree/listDocsByPath` | listDocsByPath | 文档树列出sBy路径 | notebook.get_child_docs<br>document.get_child_docs<br>document.ensure_link_targets | ✅ 已覆盖 |
 | 3 | POST | `/api/filetree/getDoc` | getDoc | 文档树获取 | document.get_doc | ✅ 已覆盖 |
 | 4 | POST | `/api/filetree/getDocCreateSavePath` | getDocCreateSavePath | 文档树获取CreateSave路径 | - | ❌ 未覆盖 |
 | 5 | POST | `/api/filetree/getRefCreateSavePath` | getRefCreateSavePath | 文档树获取引用CreateSave路径 | - | ❌ 未覆盖 |
 | 6 | POST | `/api/filetree/changeSort` | changeSort | 文档树changeSort | - | ❌ 未覆盖 |
-| 7 | POST | `/api/filetree/createDocWithMd` | createDocWithMd | 文档树创建WithMd | document.create | ✅ 已覆盖 |
+| 7 | POST | `/api/filetree/createDocWithMd` | createDocWithMd | 文档树创建WithMd | document.create<br>document.ensure_link_targets | ✅ 已覆盖 |
 | 8 | POST | `/api/filetree/createDailyNote` | createDailyNote | 文档树创建DailyNote | document.create_daily_note | ✅ 已覆盖 |
 | 9 | POST | `/api/filetree/createDoc` | createDoc | 文档树创建 | document.create | ✅ 已覆盖 |
 | 10 | POST | `/api/filetree/renameDoc` | renameDoc | 文档树重命名 | document.rename | ✅ 已覆盖 |
@@ -197,8 +197,8 @@
 | 17 | POST | `/api/filetree/duplicateDoc` | duplicateDoc | 文档树复制 | document.duplicate | ✅ 已覆盖 |
 | 18 | POST | `/api/filetree/getHPathByPath` | getHPathByPath | 文档树获取H路径By路径 | document.resolve | ✅ 已覆盖 |
 | 19 | POST | `/api/filetree/getHPathsByPaths` | getHPathsByPaths | 文档树获取H路径sBy路径s | - | ❌ 未覆盖 |
-| 20 | POST | `/api/filetree/getHPathByID` | getHPathByID | 文档树获取H路径ByID | document.resolve | ✅ 已覆盖 |
-| 21 | POST | `/api/filetree/getPathByID` | getPathByID | 文档树获取路径ByID | document.resolve | ✅ 已覆盖 |
+| 20 | POST | `/api/filetree/getHPathByID` | getHPathByID | 文档树获取H路径ByID | document.resolve<br>document.ensure_link_targets | ✅ 已覆盖 |
+| 21 | POST | `/api/filetree/getPathByID` | getPathByID | 文档树获取路径ByID | document.resolve<br>document.ensure_link_targets | ✅ 已覆盖 |
 | 22 | POST | `/api/filetree/getFullHPathByID` | getFullHPathByID | 文档树获取FullH路径ByID | - | ❌ 未覆盖 |
 | 23 | POST | `/api/filetree/getIDsByHPath` | getIDsByHPath | 文档树获取ID列表ByH路径 | document.resolve | ✅ 已覆盖 |
 | 24 | POST | `/api/filetree/doc2Heading` | doc2Heading | 文档树doc2Heading | document.doc_to_heading | ✅ 已覆盖 |

--- a/docs/reference/tools/document.md
+++ b/docs/reference/tools/document.md
@@ -13,7 +13,7 @@ Related pages:
 
 | Group | Actions |
 |------|---------|
-| Create and read | `create`, `lookup`, `get_doc`, `get_outline` |
+| Create and read | `create`, `lookup`, `ensure_link_targets`, `get_doc`, `get_outline` |
 | Tree navigation | `get_child_blocks`, `get_child_docs`, `list_tree`, `search_docs` |
 | Metadata and mutations | `rename`, `move`, `remove`, `set_attr`, `duplicate` |
 | Daily note / conversion | `create_daily_note`, `heading_to_doc`, `doc_to_heading` |
@@ -22,6 +22,8 @@ Related pages:
 
 - `create` takes either a human-readable `path`, or `parentPath` + `title`; omit `markdown` to create an empty document. Prefer `path` for child documents. The `parentPath` + `title` mode accepts either a human-readable parent path or a storage path ending in `.sy` returned by `lookup`.
 - `lookup` resolves by `id`, storage `path`, or human-readable `hpath` / `hPath`; use `include` to request `id`, `ids`, `path`, `hpath`, or `docInfo`.
+- `ensure_link_targets` provisions a reusable import link map inside one exact scope: `notebook` + direct-parent `parentId`. `resolve` and `reuse` accept only explicit direct-child document IDs. `create` accepts explicit new titles, but never treats a matching existing title as identity: it reports `same_title_child_requires_explicit_id` in `unresolved` instead. Every resolved or created output includes exact `id`, notebook, storage `path`, and `hPath` readback.
+- `ensure_link_targets(dryRun=true)` is valid only for `mode="create"`; it inspects and reports `wouldCreate` without mutation. `resolve` and `reuse` are read-only discovery operations. A real `create` follows the normal two-call contract: preflight with `validateOnly=true`, then exactly one request with a fresh UUIDv7 `requestId` and returned `expectedStructureHash`. Do not retry after an unknown transport outcome: inspect or reuse the original request ID. The action never automatically removes documents it created.
 - The returned `idPath` includes available `id` / `ids`. When several documents share the same hpath, `include: ["ids"]` returns all matching IDs; the tool includes a SQL fallback.
 - `rename`, `remove`, and `move` often need a storage path if you are not using document IDs.
 - `get_child_docs` requires a document `id`; it does not accept `notebook + path`.
@@ -43,6 +45,7 @@ Related pages:
 
 - `remove` and `move` require explicit confirmation.
 - Always resolve document path type before mutating by path.
+- Never use a title search result as a link target. Re-run `ensure_link_targets` in `resolve` or `reuse` mode with the exact ID returned by an earlier successful result.
 
 ## Examples
 
@@ -65,17 +68,31 @@ MCP:
 }
 ```
 
+```json
+{
+  "action": "ensure_link_targets",
+  "notebook": "<notebook-id>",
+  "parentId": "<parent-document-id>",
+  "mode": "reuse",
+  "targets": [{ "key": "source-index", "id": "<direct-child-document-id>" }]
+}
+```
+
+For a new target, call the same action first with `mode: "create"` and `validateOnly: true`, then commit exactly once using the returned `expectedStructureHash`, a fresh UUIDv7 `requestId`, and an explicit title target. A same-title child is an unresolved result, not an implicit reuse.
+
 CLI:
 
 ```bash
 siyuan document create --notebook <notebook-id> --path "/Inbox/Weekly Note" --markdown "Weekly report body"
 siyuan document lookup --id <doc-id> --include path
+siyuan document ensure_link_targets --notebook <notebook-id> --parent-id <parent-document-id> --mode reuse --targets-json '[{"key":"source-index","id":"<direct-child-document-id>"}]'
 ```
 
 ## Action List
 
 - `create`
 - `lookup`
+- `ensure_link_targets`
 - `rename`
 - `remove`
 - `move`

--- a/docs/reference/tools/index.md
+++ b/docs/reference/tools/index.md
@@ -13,7 +13,7 @@ Related pages:
 |------|---------|------|
 | `fs` | 8 | [fs](./fs.md) |
 | `notebook` | 11 | [notebook](./notebook.md) |
-| `document` | 16 | [document](./document.md) |
+| `document` | 17 | [document](./document.md) |
 | `block` | 21 | [block](./block.md) |
 | `av` | 12 | [av](./av.md) |
 | `file` | 17 | [file](./file.md) |
@@ -30,7 +30,7 @@ Related pages:
 
 - `fs`: ls, tree, read, write, replace, rm, mv, search
 - `notebook`: list, create, set_open_state, remove, rename, get_conf, set_conf, set_icon, get_permissions, set_permission, get_child_docs
-- `document`: create, lookup, rename, remove, move, get_child_blocks, get_child_docs, set_attr, list_tree, search_docs, get_doc, get_outline, create_daily_note, duplicate, heading_to_doc, doc_to_heading
+- `document`: create, lookup, ensure_link_targets, rename, remove, move, get_child_blocks, get_child_docs, set_attr, list_tree, search_docs, get_doc, get_outline, create_daily_note, duplicate, heading_to_doc, doc_to_heading
 - `block`: insert, prepend, append, update, replace, delete, move, set_fold_state, get_kramdown, batch_kramdown, get_children, transfer_references, set_attrs, get_attrs, info, breadcrumb, dom, recent_updated, word_count, add_to_daily_note, docs_info
 - `av`: get, render, get_attribute_view_keys, get_attribute_view_filter_sort, search, add_rows, remove_rows, add_column, remove_column, set_cells, duplicate, get_primary_key_values
 - `file`: upload_asset, list_templates, read_template, create_template, update_template, delete_template, save_doc_as_template, render, export_md, export_resources, list_unused_assets, get_doc_assets, get_image_ocr_text, remove_unused_assets, rename_asset, delete_asset, extract_doc

--- a/docs/zh/reference/tools/document.md
+++ b/docs/zh/reference/tools/document.md
@@ -13,7 +13,7 @@
 
 | 分组 | 动作 |
 |------|---------|
-| 创建与读取 | `create`, `lookup`, `get_doc`, `get_outline` |
+| 创建与读取 | `create`, `lookup`, `ensure_link_targets`, `get_doc`, `get_outline` |
 | 树结构查询 | `get_child_blocks`, `get_child_docs`, `list_tree`, `search_docs` |
 | 元数据与修改 | `rename`, `move`, `remove`, `set_attr`, `duplicate` |
 | 日记 / 转换 | `create_daily_note`, `heading_to_doc`, `doc_to_heading` |
@@ -22,6 +22,8 @@
 
 - `create` 支持人类可读 `path`，也支持 `parentPath` + `title`；省略 `markdown` 即创建空文档。创建子文档时优先使用 `path`。`parentPath` + `title` 可传人类可读父路径，也可传 `lookup` 返回的 `.sy` 结尾 storage path。
 - `lookup` 可按 `id`、存储 `path`、人类可读 `hpath` / `hPath` 查找；用 `include` 请求 `id`、`ids`、`path`、`hpath` 或 `docInfo`。
+- `ensure_link_targets` 在一个精确范围内建立可复用的导入 link map：范围必须是 `notebook` + 直属父文档 `parentId`。`resolve` 与 `reuse` 只接受明确的直属子文档 ID。`create` 只接受明确的新标题；即使当前范围已有同名子文档，也绝不把标题当身份复用，而是把它以 `same_title_child_requires_explicit_id` 放进 `unresolved`。每个解析或新建结果都带有精确 `id`、笔记本、storage `path` 和 `hPath` 读回。
+- `ensure_link_targets(dryRun=true)` 只适用于 `mode="create"`，只检查并返回 `wouldCreate`，不写入。`resolve` 与 `reuse` 都是纯只读发现操作。真正的 `create` 使用普通两段式合同：先 `validateOnly=true` 预检，再用新的 UUIDv7 `requestId` 和返回的 `expectedStructureHash` 只提交一次。传输结果未知时不得重发，必须检查或继续使用原 request ID。该 action 不会自动删除自己创建的文档。
 - `lookup` 返回的 `idPath` 会包含可用的 `id` / `ids`。当同一 hpath 有多个同名文档时，`include: ["ids"]` 会返回全部匹配 ID；内部已包含 SQL 兜底。
 - `rename`、`remove`、`move` 在非 ID 模式下通常需要存储路径。
 - `get_child_docs` 必须传文档 `id`，不接受 `notebook + path`。
@@ -43,6 +45,7 @@
 
 - `remove`、`move` 需要显式确认。
 - 按路径修改前先确认路径类型。
+- 不要把标题搜索结果当链接目标。再次运行 `ensure_link_targets` 时，使用上次成功响应中的精确 ID，并选 `resolve` 或 `reuse`。
 
 ## 示例
 
@@ -65,17 +68,31 @@ MCP：
 }
 ```
 
+```json
+{
+  "action": "ensure_link_targets",
+  "notebook": "<notebook-id>",
+  "parentId": "<parent-document-id>",
+  "mode": "reuse",
+  "targets": [{ "key": "source-index", "id": "<direct-child-document-id>" }]
+}
+```
+
+要新建目标时，用 `mode: "create"` 和 `validateOnly: true` 先预检；随后带返回的 `expectedStructureHash`、新的 UUIDv7 `requestId` 和明确 title target 只提交一次。遇到同名直属子文档时，结果是 unresolved，不会隐式复用。
+
 CLI：
 
 ```bash
 siyuan document create --notebook <notebook-id> --path "/Inbox/Weekly Note" --markdown "周报正文"
 siyuan document lookup --id <doc-id> --include path
+siyuan document ensure_link_targets --notebook <notebook-id> --parent-id <parent-document-id> --mode reuse --targets-json '[{"key":"source-index","id":"<direct-child-document-id>"}]'
 ```
 
 ## 动作列表
 
 - `create`
 - `lookup`
+- `ensure_link_targets`
 - `rename`
 - `remove`
 - `move`

--- a/docs/zh/reference/tools/index.md
+++ b/docs/zh/reference/tools/index.md
@@ -13,7 +13,7 @@
 |------|-------------|------|
 | `fs` | 8 | [fs 工具](./fs.md) |
 | `notebook` | 11 | [notebook 工具](./notebook.md) |
-| `document` | 16 | [document 工具](./document.md) |
+| `document` | 17 | [document 工具](./document.md) |
 | `block` | 21 | [block 工具](./block.md) |
 | `av` | 12 | [av 工具](./av.md) |
 | `file` | 17 | [file 工具](./file.md) |
@@ -30,7 +30,7 @@
 
 - `fs`: ls, tree, read, write, replace, rm, mv, search
 - `notebook`: list, create, set_open_state, remove, rename, get_conf, set_conf, set_icon, get_permissions, set_permission, get_child_docs
-- `document`: create, lookup, rename, remove, move, get_child_blocks, get_child_docs, set_attr, list_tree, search_docs, get_doc, get_outline, create_daily_note, duplicate, heading_to_doc, doc_to_heading
+- `document`: create, lookup, ensure_link_targets, rename, remove, move, get_child_blocks, get_child_docs, set_attr, list_tree, search_docs, get_doc, get_outline, create_daily_note, duplicate, heading_to_doc, doc_to_heading
 - `block`: insert, prepend, append, update, replace, delete, move, set_fold_state, get_kramdown, batch_kramdown, get_children, transfer_references, set_attrs, get_attrs, info, breadcrumb, dom, recent_updated, word_count, add_to_daily_note, docs_info
 - `av`: get, render, get_attribute_view_keys, get_attribute_view_filter_sort, search, add_rows, remove_rows, add_column, remove_column, set_cells, duplicate, get_primary_key_values
 - `file`: upload_asset, list_templates, read_template, create_template, update_template, delete_template, save_doc_as_template, render, export_md, export_resources, list_unused_assets, get_doc_assets, get_image_ocr_text, remove_unused_assets, rename_asset, delete_asset, extract_doc

--- a/public/i18n/en_US.json
+++ b/public/i18n/en_US.json
@@ -356,6 +356,8 @@
     "desc_document_action_resolve": "Resolve document IDs, storage paths, hierarchical paths, and optional document info.",
     "document_action_lookup": "Lookup Document Reference",
     "desc_document_action_lookup": "Look up document IDs, storage paths, human-readable paths, and metadata.",
+    "document_action_ensure_link_targets": "Ensure Link Targets",
+    "desc_document_action_ensure_link_targets": "Resolve or reuse explicit direct-child document IDs, or create explicitly named missing child targets with exact readback.",
     "document_action_get_child_blocks": "Get Child Blocks",
     "desc_document_action_get_child_blocks": "Get direct child blocks by document ID.",
     "document_action_get_child_docs": "Get Child Documents",

--- a/public/i18n/zh_CN.json
+++ b/public/i18n/zh_CN.json
@@ -344,6 +344,8 @@
     "desc_document_action_resolve": "解析文档 ID、存储路径、层级路径和可选文档信息。",
     "document_action_lookup": "查找文档引用",
     "desc_document_action_lookup": "查找文档 ID、存储路径、可读路径和元数据。",
+    "document_action_ensure_link_targets": "确保链接目标",
+    "desc_document_action_ensure_link_targets": "解析或复用明确的直属子文档 ID，或创建明确命名的缺失子目标并做精确读回。",
     "document_action_get_child_blocks": "获取子块",
     "desc_document_action_get_child_blocks": "通过文档 ID 获取直属子块。",
     "document_action_get_child_docs": "获取子文档",

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -6,7 +6,7 @@ export type ToolCategory = typeof TOOL_CATEGORIES[number];
 
 export const FS_ACTIONS = ['ls', 'tree', 'read', 'write', 'replace', 'rm', 'mv', 'search'] as const;
 export const NOTEBOOK_ACTIONS = ['list', 'create', 'set_open_state', 'remove', 'rename', 'get_conf', 'set_conf', 'set_icon', 'get_permissions', 'set_permission', 'get_child_docs'] as const;
-export const DOCUMENT_ACTIONS = ['create', 'lookup', 'rename', 'remove', 'move', 'get_child_blocks', 'get_child_docs', 'set_attr', 'list_tree', 'search_docs', 'get_doc', 'get_outline', 'create_daily_note', 'duplicate', 'heading_to_doc', 'doc_to_heading'] as const;
+export const DOCUMENT_ACTIONS = ['create', 'lookup', 'ensure_link_targets', 'rename', 'remove', 'move', 'get_child_blocks', 'get_child_docs', 'set_attr', 'list_tree', 'search_docs', 'get_doc', 'get_outline', 'create_daily_note', 'duplicate', 'heading_to_doc', 'doc_to_heading'] as const;
 export const BLOCK_ACTIONS = ['insert', 'prepend', 'append', 'update', 'replace', 'delete', 'move', 'set_fold_state', 'get_kramdown', 'batch_kramdown', 'get_children', 'transfer_references', 'set_attrs', 'get_attrs', 'info', 'breadcrumb', 'dom', 'recent_updated', 'word_count', 'add_to_daily_note', 'docs_info'] as const;
 export const AV_ACTIONS = ['get', 'render', 'get_attribute_view_keys', 'get_attribute_view_filter_sort', 'search', 'add_rows', 'remove_rows', 'add_column', 'remove_column', 'set_cells', 'duplicate', 'get_primary_key_values'] as const;
 export const FILE_ACTIONS = ['upload_asset', 'list_templates', 'read_template', 'create_template', 'update_template', 'delete_template', 'save_doc_as_template', 'render', 'export_md', 'export_resources', 'list_unused_assets', 'get_doc_assets', 'get_image_ocr_text', 'remove_unused_assets', 'rename_asset', 'delete_asset', 'extract_doc'] as const;
@@ -168,6 +168,7 @@ const ACTION_TIERS: Record<ToolCategory, Record<string, ActionTier>> = {
     },
     document: {
         create: 'basic', lookup: 'basic', get_doc: 'basic', get_outline: 'basic',
+        ensure_link_targets: 'advanced',
         get_child_blocks: 'basic', get_child_docs: 'basic',
         search_docs: 'basic', rename: 'basic',
         remove: 'advanced', move: 'advanced', set_attr: 'advanced',
@@ -280,7 +281,7 @@ export function buildDefaultToolConfig(): ToolConfig {
         },
         document: {
             enabled: true,
-            actions: createActionsRecord(DOCUMENT_ACTIONS, ['create', 'lookup', 'rename', 'move', 'get_child_blocks', 'get_child_docs', 'set_attr', 'list_tree', 'search_docs', 'get_doc', 'get_outline', 'create_daily_note', 'duplicate', 'heading_to_doc', 'doc_to_heading']),
+            actions: createActionsRecord(DOCUMENT_ACTIONS, ['create', 'lookup', 'ensure_link_targets', 'rename', 'move', 'get_child_blocks', 'get_child_docs', 'set_attr', 'list_tree', 'search_docs', 'get_doc', 'get_outline', 'create_daily_note', 'duplicate', 'heading_to_doc', 'doc_to_heading']),
         },
         block: {
             enabled: true,

--- a/src/core/document-link-targets.ts
+++ b/src/core/document-link-targets.ts
@@ -1,0 +1,146 @@
+import type { SiYuanClient } from '../api/client';
+import * as blockApi from '../api/block';
+import * as documentApi from '../api/document';
+
+/**
+ * The link-target action deliberately resolves only document IDs. Titles are
+ * user-facing labels and can repeat or change; accepting them as identities
+ * would let an import silently link to the wrong note. Creation is the sole
+ * place a title is accepted, and it is never used to adopt an existing note.
+ */
+export interface LinkTargetDocumentIdentity {
+    id: string;
+    notebook: string;
+    path: string;
+    hPath: string;
+    name?: string;
+}
+
+export interface LinkTargetChildSummary {
+    id: string;
+    notebook: string;
+    path: string;
+    hPath?: string;
+    name?: string;
+}
+
+export interface LinkTargetScope {
+    parent: LinkTargetDocumentIdentity;
+    children: LinkTargetChildSummary[];
+}
+
+export interface LinkTargetScopeRequest {
+    notebook: string;
+    parentId: string;
+}
+
+export function linkTargetError(code: string, message: string): Error & { code: string } {
+    return Object.assign(new Error(message), { name: 'DocumentLinkTargetError', code });
+}
+
+function normalizePath(value: string): string {
+    return value.startsWith('/') ? value : `/${value}`;
+}
+
+function childIdFromPath(path: string): string | undefined {
+    const name = normalizePath(path).split('/').filter(Boolean).at(-1);
+    if (!name?.endsWith('.sy')) return undefined;
+    return name.slice(0, -3);
+}
+
+function stripSySuffix(value: string | undefined): string | undefined {
+    return typeof value === 'string' ? value.replace(/\.sy$/i, '') : undefined;
+}
+
+/**
+ * Read a document through three independent API projections. A successful
+ * create response alone is not enough: the returned ID must still resolve to
+ * the expected notebook, storage path, hierarchical path, and document root.
+ */
+export async function readLinkTargetDocumentIdentity(
+    client: SiYuanClient,
+    id: string,
+    expectedNotebook?: string,
+): Promise<LinkTargetDocumentIdentity> {
+    const [pathInfo, hPath, docInfo] = await Promise.all([
+        documentApi.getPathByID(client, id),
+        documentApi.getHPathByID(client, id),
+        blockApi.getDocInfo(client, id),
+    ]);
+    if (!docInfo || typeof docInfo !== 'object') {
+        throw linkTargetError('target_readback_incomplete', `Link target ${id} did not return document-root metadata.`);
+    }
+    const rootID = typeof docInfo.rootID === 'string' && docInfo.rootID.length > 0
+        ? docInfo.rootID
+        : docInfo.id;
+    if (rootID !== id) {
+        throw linkTargetError(
+            'target_not_document_root',
+            `Link target ${id} resolved to document root ${rootID}; declare a document ID, not a descendant block ID.`,
+        );
+    }
+    if (!pathInfo.notebook || !pathInfo.path || !hPath) {
+        throw linkTargetError('target_readback_incomplete', `Link target ${id} did not return a complete ID/path/HPath readback.`);
+    }
+    if (expectedNotebook && pathInfo.notebook !== expectedNotebook) {
+        throw linkTargetError(
+            'target_outside_notebook',
+            `Link target ${id} resolved in notebook ${pathInfo.notebook}, outside explicit notebook scope ${expectedNotebook}.`,
+        );
+    }
+    return {
+        id,
+        notebook: pathInfo.notebook,
+        path: normalizePath(pathInfo.path),
+        hPath,
+        ...(typeof docInfo.name === 'string' && docInfo.name ? { name: stripSySuffix(docInfo.name) } : {}),
+    };
+}
+
+/**
+ * Resolve the parent by its explicit ID and list only its direct child
+ * documents. This is the whole authority scope for link provisioning; search
+ * results, document titles, and UI position are intentionally not consulted.
+ */
+export async function readLinkTargetScope(
+    client: SiYuanClient,
+    request: LinkTargetScopeRequest,
+): Promise<LinkTargetScope> {
+    const parent = await readLinkTargetDocumentIdentity(client, request.parentId, request.notebook);
+    const listed = await documentApi.listDocsByPath(client, request.notebook, parent.path);
+    if (listed.box && listed.box !== request.notebook) {
+        throw linkTargetError(
+            'parent_scope_mismatch',
+            `Parent ${request.parentId} listed children from notebook ${listed.box}, outside explicit notebook scope ${request.notebook}.`,
+        );
+    }
+    if ((listed.files ?? []).some((file) => file.box && file.box !== request.notebook)) {
+        throw linkTargetError(
+            'parent_scope_mismatch',
+            `Parent ${request.parentId} returned a child from outside explicit notebook scope ${request.notebook}.`,
+        );
+    }
+    const children = (listed.files ?? []).flatMap((file): LinkTargetChildSummary[] => {
+        const id = typeof file.id === 'string' && file.id.length > 0 ? file.id : childIdFromPath(file.path);
+        if (!id || !file.path) return [];
+        return [{
+            id,
+            notebook: file.box || listed.box || request.notebook,
+            path: normalizePath(file.path),
+            ...(typeof file.hPath === 'string' && file.hPath ? { hPath: file.hPath } : {}),
+            ...(typeof file.name === 'string' && file.name ? { name: stripSySuffix(file.name) } : {}),
+        }];
+    });
+    return { parent, children };
+}
+
+export function findScopedLinkTarget(
+    scope: LinkTargetScope,
+    id: string,
+): LinkTargetChildSummary | undefined {
+    return scope.children.find((child) => child.id === id);
+}
+
+export function scopedLinkTargetTitleExists(scope: LinkTargetScope, title: string): boolean {
+    return scope.children.some((child) => child.name === title);
+}

--- a/src/core/help.ts
+++ b/src/core/help.ts
@@ -50,6 +50,7 @@ export const DOCUMENT_GUIDANCE: string[] = [
     'For document(action="lookup"), path means a storage path such as /20240318112233-abc123.sy; use hpath/hPath for human-readable paths such as /Inbox/Weekly Note.',
     'Other document actions that use notebook + path expect storage paths returned by document(action="lookup").',
     'If document(action="create") reports a duplicate-name error, verify the intended child with document(action="lookup", notebook=..., hpath="/Folder/Parent/New Child", include=["id","path","hpath"]) or document(action="get_child_docs", id=<parent-doc-id>). New create results may take a short indexing delay before lookup/search sees them.',
+    'document(action="ensure_link_targets") is the bounded import-link provisioner: scope it with notebook + parentId, reuse only explicit child document IDs, and use create only for explicit new titles. It never guesses an existing target from a title; same-title children are unresolved and require an ID decision.',
     'A safe path-based workflow is lookup -> rename/remove/move.',
     'document(action="get_child_blocks") and document(action="get_child_docs") return direct children for a document ID.',
     'document(action="set_attr") updates document metadata such as icon and cover; use attrs.cover=null or an empty string to clear the cover.',
@@ -181,6 +182,7 @@ export const NOTEBOOK_ACTION_HINTS: Partial<Record<NotebookAction, string>> = {
 export const DOCUMENT_ACTION_HINTS: Partial<Record<DocumentAction, string>> = {
     create: 'Use notebook + path for the most direct child-document flow. path is a notebook-local hpath like /Folder/Parent/New Child, not /Notebook/... and not .sy. parentPath + title is also supported. markdown is optional and must not start with # Title; a matching leading H1 is stripped to avoid duplicate titles.',
     lookup: 'Look up one reference at a time. Use id, notebook + storage path, or notebook + hpath/hPath. The path field means storage path like /20240318112233-abc123.sy; use hpath for human-readable paths.',
+    ensure_link_targets: 'Scope every request with an explicit notebook ID and parent document ID. resolve/reuse require existing child document IDs and never fall back to titles. create accepts explicit new titles only; if a same-title child already exists, it is returned as unresolved rather than guessed or reused. dryRun performs zero writes only for create. resolve/reuse are read-only; create uses strict validateOnly preflight, then one commit with a fresh UUIDv7 requestId plus expectedStructureHash. Responses contain exact ID/path/HPath readback and resolved/created/reused/unresolved accounting.',
     rename: 'Use either id + title or notebook + path + title.',
     remove: 'Use either id or notebook + storage path. This action requires explicit user confirmation. If bulk ids/paths hit SiYuan\'s short indexing window, retry by deleting one document at a time with notebook + storage path.',
     move: 'Use either fromIDs + toID or fromPaths + toNotebook + toPath. For path-based moves, toPath must be the storage path of an existing destination document. This action requires explicit user confirmation.',

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -277,6 +277,69 @@ export const DocumentLookupSchema = z.object({
     }
 });
 
+const DocumentLinkTargetSchema = z.object({
+    key: z.string().trim().min(1).max(256).describe('Stable caller key used in the returned link map. It is not resolved as a document title.'),
+    id: z.string().trim().min(1).optional().describe('Explicit existing document ID. Required for mode="resolve" and mode="reuse".'),
+    title: z.string().trim().min(1).max(256).optional().describe('Explicit title for a new direct child document. Allowed only for mode="create" and never used to adopt an existing document.'),
+}).superRefine((value, ctx) => {
+    if (value.id && value.title) {
+        ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'Each link target must provide either id or title, not both.',
+        });
+    }
+    if (value.title && /[\\/]/.test(value.title)) {
+        ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['title'],
+            message: 'Link-target titles must be one direct child name and cannot contain / or \\.',
+        });
+    }
+});
+
+/**
+ * This contract intentionally has no title lookup branch. A caller first
+ * resolves a concrete parent ID, then either supplies exact existing target
+ * IDs or explicitly asks to create named children. Matching a duplicate title
+ * only fails closed; it never turns into an implicit reuse decision.
+ */
+export const DocumentEnsureLinkTargetsSchema = z.object({
+    action: z.literal('ensure_link_targets'),
+    notebook: z.string().trim().min(1).describe('Explicit notebook ID that must own the parent document and every returned target.'),
+    parentId: z.string().trim().min(1).describe('Explicit parent document ID. Only direct child documents of this resolved parent are in scope.'),
+    mode: z.enum(['resolve', 'reuse', 'create']).describe('resolve/reuse accept exact existing IDs without title fallback; create accepts explicit new titles and refuses to adopt same-title children.'),
+    targets: z.array(DocumentLinkTargetSchema).min(1).max(100).describe('Explicit link targets. keys must be unique; IDs are identities, while titles are only new-document names.'),
+    markdown: z.string().optional().describe('Optional Markdown body for every target created by mode="create". Existing targets are never edited.'),
+    dryRun: z.boolean().optional().describe('Plan and inspect the explicit scope without creating documents. For strict creation preflight, use validateOnly=true instead.'),
+}).superRefine((value, ctx) => {
+    const keys = new Set<string>();
+    const titles = new Set<string>();
+    for (const [index, target] of value.targets.entries()) {
+        if (keys.has(target.key)) {
+            ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['targets', index, 'key'], message: 'Link-target keys must be unique.' });
+        }
+        keys.add(target.key);
+        if (value.mode === 'create' && !target.title) {
+            ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['targets', index, 'title'], message: 'mode="create" requires an explicit title for every target.' });
+        }
+        if (value.mode === 'create' && target.title) {
+            if (titles.has(target.title)) {
+                ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['targets', index, 'title'], message: 'mode="create" target titles must be unique within one request.' });
+            }
+            titles.add(target.title);
+        }
+        if (value.mode !== 'create' && !target.id) {
+            ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['targets', index, 'id'], message: `mode="${value.mode}" requires an explicit existing document ID for every target.` });
+        }
+    }
+    if (value.mode !== 'create' && value.markdown !== undefined) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['markdown'], message: 'markdown is only valid for mode="create"; resolve/reuse never edit targets.' });
+    }
+    if (value.dryRun === true && value.mode !== 'create') {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['dryRun'], message: 'dryRun is only valid for mode="create"; resolve and reuse are already read-only.' });
+    }
+});
+
 export const DocumentRenameSchema = z.object({
     action: z.literal("rename"),
     title: z.string().describe("New document title"),

--- a/src/core/write-safety-coordinator.ts
+++ b/src/core/write-safety-coordinator.ts
@@ -4,6 +4,7 @@ import type { SiYuanClient } from '../api/client';
 import { WriteOutcomeUnknownError } from '../api/client';
 import { normalizeTemplatePath, readTemplateSource } from '../api/template';
 import { readPuppyStats } from './puppy-state';
+import { readLinkTargetScope } from './document-link-targets';
 import type { PermissionManager } from './permissions';
 import type { ToolResult } from '../tools/internal/shared';
 import {
@@ -371,6 +372,11 @@ function derivePostWriteProbeArgs(
     if (category === 'document' && action === 'duplicate' && payload && typeof payload.id === 'string') {
         return { ...args, id: payload.id };
     }
+    if (category === 'document' && action === 'ensure_link_targets' && payload && isRecord(payload.linkMap)) {
+        const resolvedTargetIds = Object.values(payload.linkMap)
+            .flatMap((value) => isRecord(value) && typeof value.id === 'string' ? [value.id] : []);
+        return { ...args, resolvedTargetIds };
+    }
     if (category === 'av' && action === 'duplicate' && payload && typeof payload.avID === 'string') {
         return {
             ...args,
@@ -550,6 +556,28 @@ async function probeCurrentState(
         await appendBlockRows(client, args, state);
     } else if (category === 'system') {
         state.system = await client.requestRead('/api/system/getConf', {});
+    } else if (category === 'document' && action === 'ensure_link_targets') {
+        const notebook = typeof args.notebook === 'string' ? args.notebook : '';
+        const parentId = typeof args.parentId === 'string' ? args.parentId : '';
+        if (!notebook || !parentId) {
+            throw safetyError('precondition_required', 'document.ensure_link_targets requires explicit notebook and parentId scope.');
+        }
+        const scope = await readLinkTargetScope(client, { notebook, parentId });
+        const declaredTargetIds = Array.isArray(args.targets)
+            ? args.targets.flatMap((target) => isRecord(target) && typeof target.id === 'string' ? [target.id] : [])
+            : [];
+        const resolvedTargetIds = Array.isArray(args.resolvedTargetIds)
+            ? args.resolvedTargetIds.filter((id): id is string => typeof id === 'string')
+            : [];
+        state.documentLinkTargetScope = {
+            notebookID: notebook,
+            parent: scope.parent,
+            // Creation must freeze the complete direct-child list, not a
+            // title search result, so same-title collisions and concurrent
+            // child creation invalidate the preflight structure credential.
+            children: scope.children,
+            declaredTargetIds: [...new Set([...declaredTargetIds, ...resolvedTargetIds])].sort(),
+        };
     } else {
         await appendBlockRows(client, args, state);
     }
@@ -865,6 +893,15 @@ function collectTargetSelectors(args: Record<string, unknown>): string[] {
         if (typeof value === 'string' && value.trim()) values.add(value.trim());
         if (Array.isArray(value)) {
             for (const item of value) if (typeof item === 'string' && item.trim()) values.add(item.trim());
+        }
+    }
+    if (typeof args.parentId === 'string' && args.parentId.trim()) values.add(args.parentId.trim());
+    if (Array.isArray(args.resolvedTargetIds)) {
+        for (const id of args.resolvedTargetIds) if (typeof id === 'string' && id.trim()) values.add(id.trim());
+    }
+    if (Array.isArray(args.targets)) {
+        for (const target of args.targets) {
+            if (isRecord(target) && typeof target.id === 'string' && target.id.trim()) values.add(target.id.trim());
         }
     }
     return [...values].sort();

--- a/src/core/write-safety-policy.ts
+++ b/src/core/write-safety-policy.ts
@@ -42,7 +42,7 @@ export const ACTION_SAFETY_POLICIES: {
     document: {
         lookup: read(), get_child_blocks: read(), get_child_docs: read(), list_tree: read(), search_docs: read(),
         get_doc: read(), get_outline: read(),
-        create: mutation(), create_daily_note: mutation(), duplicate: mutation('state'), rename: mutation('state'),
+        create: mutation(), ensure_link_targets: mutation('structure'), create_daily_note: mutation(), duplicate: mutation('state'), rename: mutation('state'),
         remove: mutation('state'), move: mutation('structure'), set_attr: mutation('state'),
         heading_to_doc: mutation('structure'), doc_to_heading: mutation('structure'),
     },
@@ -118,6 +118,16 @@ export function getActionSafetyPolicy(
     // kernel to create a missing database.
     if (category === 'av' && action === 'render') {
         return args.createIfNotExist === true ? mutation() : read();
+    }
+    // Existing-target resolution never changes SiYuan state: both resolve and
+    // reuse require only read permission and return the exact supplied IDs.
+    // Creation alone freezes the parent child list under a structural lease.
+    // That credential catches a same-title collision or concurrent child
+    // creation between preflight and the final dispatch.
+    if (category === 'document' && action === 'ensure_link_targets') {
+        return args.dryRun === true || args.mode === 'resolve' || args.mode === 'reuse'
+            ? read()
+            : mutation('structure');
     }
     return policy;
 }

--- a/src/tools/document/handlers.ts
+++ b/src/tools/document/handlers.ts
@@ -7,6 +7,7 @@ import type { DocumentAction } from '../../core/config';
 import type { PermissionManager } from '../../core/permissions';
 import {
     DocumentCreateSchema,
+    DocumentEnsureLinkTargetsSchema,
     DocumentCreateDailyNoteSchema,
     DocumentDocToHeadingSchema,
     DocumentDuplicateSchema,
@@ -23,6 +24,15 @@ import {
     DocumentSearchDocsSchema,
     DocumentSetAttrSchema,
 } from '../../core/types';
+import {
+    findScopedLinkTarget,
+    linkTargetError,
+    readLinkTargetDocumentIdentity,
+    readLinkTargetScope,
+    scopedLinkTargetTitleExists,
+    type LinkTargetDocumentIdentity,
+    type LinkTargetScope,
+} from '../../core/document-link-targets';
 import {
     ensurePermissionForDocumentId,
     ensurePermissionForNotebook,
@@ -457,6 +467,175 @@ const handleLookup: DocumentActionHandler = async ({ client, permMgr, rawArgs })
     return createJsonResult(createLookupPathResult(result));
 };
 
+interface LinkTargetResult {
+    key: string;
+    disposition: 'created' | 'resolved' | 'reused';
+    id: string;
+    notebook: string;
+    path: string;
+    hPath: string;
+    title?: string;
+}
+
+interface UnresolvedLinkTarget {
+    key: string;
+    id?: string;
+    title?: string;
+    reason: string;
+}
+
+function toLinkTargetResult(
+    key: string,
+    disposition: LinkTargetResult['disposition'],
+    identity: LinkTargetDocumentIdentity,
+): LinkTargetResult {
+    return {
+        key,
+        disposition,
+        id: identity.id,
+        notebook: identity.notebook,
+        path: identity.path,
+        hPath: identity.hPath,
+        ...(identity.name ? { title: identity.name } : {}),
+    };
+}
+
+function serializeLinkTargetScope(scope: LinkTargetScope): Record<string, unknown> {
+    return {
+        notebook: scope.parent.notebook,
+        parentId: scope.parent.id,
+        parentPath: scope.parent.path,
+        parentHPath: scope.parent.hPath,
+    };
+}
+
+async function readCreatedLinkTarget(
+    client: SiYuanClient,
+    notebook: string,
+    parentId: string,
+    createdId: string,
+): Promise<LinkTargetDocumentIdentity> {
+    let lastError: unknown;
+    // Creation can return before the file-tree index exposes HPath. This is
+    // a bounded readback wait only: after the first create call we never send
+    // that write again, because a response loss must not make a duplicate.
+    for (const delay of [0, 80, 160, 320, 640]) {
+        if (delay > 0) await sleep(delay);
+        try {
+            const identity = await readLinkTargetDocumentIdentity(client, createdId, notebook);
+            const currentScope = await readLinkTargetScope(client, { notebook, parentId });
+            if (!findScopedLinkTarget(currentScope, createdId)) {
+                throw linkTargetError(
+                    'created_target_outside_scope',
+                    `Created target ${createdId} did not read back as a direct child of explicit parent ${parentId}.`,
+                );
+            }
+            return identity;
+        } catch (error) {
+            lastError = error;
+        }
+    }
+    throw linkTargetError(
+        'created_target_readback_failed',
+        `Created link target ${createdId} could not be confirmed by exact ID/path/HPath and parent-child readback. Do not retry creation automatically: ${lastError instanceof Error ? lastError.message : String(lastError)}`,
+    );
+}
+
+/**
+ * Provision a link map without title discovery. `resolve` and `reuse` both
+ * require IDs from a previous exact readback; their separate dispositions let
+ * import callers preserve whether they merely verified a map or intentionally
+ * reused it. `create` accepts names only for new direct children and fails
+ * closed when the current scope already has that name.
+ */
+const handleEnsureLinkTargets: DocumentActionHandler = async ({ client, permMgr, rawArgs }) => {
+    const parsed = DocumentEnsureLinkTargetsSchema.parse(rawArgs);
+    // dryRun performs the same bounded reads but deliberately never reaches
+    // createDoc, so requiring write permission here would falsely make a
+    // no-mutation inspection unavailable to read-only import callers.
+    const required = parsed.mode === 'create' && parsed.dryRun !== true ? 'write' : 'read';
+    const denied = await ensurePermissionForNotebook(permMgr, parsed.notebook, required);
+    if (denied) return denied;
+
+    const scope = await readLinkTargetScope(client, {
+        notebook: parsed.notebook,
+        parentId: parsed.parentId,
+    });
+    const created: LinkTargetResult[] = [];
+    const resolved: LinkTargetResult[] = [];
+    const reused: LinkTargetResult[] = [];
+    const unresolved: UnresolvedLinkTarget[] = [];
+    const wouldCreate: Array<{ key: string; title: string }> = [];
+
+    if (parsed.mode !== 'create') {
+        const disposition = parsed.mode === 'resolve' ? 'resolved' : 'reused';
+        for (const target of parsed.targets) {
+            const scoped = findScopedLinkTarget(scope, target.id!);
+            if (!scoped) {
+                unresolved.push({
+                    key: target.key,
+                    id: target.id,
+                    reason: 'target_not_direct_child_of_explicit_parent',
+                });
+                continue;
+            }
+            const identity = await readLinkTargetDocumentIdentity(client, scoped.id, parsed.notebook);
+            const result = toLinkTargetResult(target.key, disposition, identity);
+            if (parsed.mode === 'resolve') resolved.push(result);
+            else reused.push(result);
+        }
+    } else {
+        for (const target of parsed.targets) {
+            const title = target.title!;
+            if (scopedLinkTargetTitleExists(scope, title)) {
+                unresolved.push({
+                    key: target.key,
+                    title,
+                    reason: 'same_title_child_requires_explicit_id',
+                });
+                continue;
+            }
+            if (parsed.dryRun === true) {
+                wouldCreate.push({ key: target.key, title });
+                continue;
+            }
+            const createdId = await documentApi.createDoc(
+                client,
+                parsed.notebook,
+                `${scope.parent.hPath.replace(/\/+$/, '')}/${title}`,
+                parsed.markdown ?? '',
+            );
+            const identity = await readCreatedLinkTarget(client, parsed.notebook, parsed.parentId, createdId);
+            created.push(toLinkTargetResult(target.key, 'created', identity));
+        }
+    }
+
+    const linkMap = Object.fromEntries(
+        [...created, ...resolved, ...reused].map((target) => [target.key, {
+            id: target.id,
+            notebook: target.notebook,
+            path: target.path,
+            hPath: target.hPath,
+        }]),
+    );
+    return applyUiRefresh(client, createJsonResult({
+        success: unresolved.length === 0,
+        mode: parsed.mode,
+        dryRun: parsed.dryRun === true,
+        scope: serializeLinkTargetScope(scope),
+        created,
+        resolved,
+        reused,
+        unresolved,
+        ...(wouldCreate.length > 0 ? { wouldCreate } : {}),
+        linkMap,
+        createdCount: created.length,
+        resolvedCount: resolved.length,
+        reusedCount: reused.length,
+        unresolvedCount: unresolved.length,
+    }), created.length > 0 ? [{ type: 'reloadFiletree' }] : []);
+};
+
 const handleRename: DocumentActionHandler = async ({ client, permMgr, rawArgs }) => {
     const parsed = DocumentRenameSchema.parse(rawArgs);
     if (parsed.id) {
@@ -820,6 +999,7 @@ const handleDocToHeading: DocumentActionHandler = async ({ client, permMgr, rawA
 export const DOCUMENT_ACTION_HANDLERS: Record<DocumentAction, DocumentActionHandler> = {
     create: handleCreate,
     lookup: handleLookup,
+    ensure_link_targets: handleEnsureLinkTargets,
     rename: handleRename,
     remove: handleRemove,
     move: handleMove,

--- a/src/tools/document/index.ts
+++ b/src/tools/document/index.ts
@@ -6,6 +6,7 @@ import {
     DocumentActionSchema,
     DocumentCreateDailyNoteSchema,
     DocumentCreateSchema,
+    DocumentEnsureLinkTargetsSchema,
     DocumentDocToHeadingSchema,
     DocumentDuplicateSchema,
     DocumentGetChildBlocksSchema,
@@ -30,6 +31,7 @@ export const DOCUMENT_TOOL_NAME = 'document';
 export const DOCUMENT_VARIANTS: ActionVariant<DocumentAction>[] = [
     createZodActionVariant('create', DocumentCreateSchema, 'Create a new document. Prefer path for child documents; parentPath + title also accepts a human-readable parent path or a storage path ending in .sy.'),
     createZodActionVariant('lookup', DocumentLookupSchema, 'Look up document IDs, storage paths, human-readable paths, and document metadata from one document reference.'),
+    createZodActionVariant('ensure_link_targets', DocumentEnsureLinkTargetsSchema, 'Resolve, reuse, or create explicitly scoped direct-child document link targets. Existing targets require IDs; titles are never guessed as identities.'),
     createZodActionVariant('rename', DocumentRenameSchema, 'Rename a document'),
     createZodActionVariant('remove', DocumentRemoveSchema, 'Delete a document'),
     createZodActionVariant('move', DocumentMoveSchema, 'Move a document to another location'),

--- a/tests/unit/core/write-safety-coordinator.test.ts
+++ b/tests/unit/core/write-safety-coordinator.test.ts
@@ -18,6 +18,122 @@ function success(payload: Record<string, unknown>) {
 }
 
 describe('write safety coordinator', () => {
+    it('preflights an explicit link-target scope, rejects a changed child list, commits once, and replays the request ID', async () => {
+        const parentId = '20260813020101-parent01';
+        const existingId = '20260813020102-child001';
+        const createdId = '20260813020103-child002';
+        let children = [{ id: existingId, name: 'Existing target', path: `/${parentId}/${existingId}.sy`, hPath: '/Imports/Existing target' }];
+        const client = {
+            readFile: vi.fn(async () => { throw new Error('HTTP error: 404 Not Found'); }),
+            writeFile: vi.fn(async () => undefined),
+            requestRead: vi.fn(async (endpoint: string, body?: Record<string, unknown>) => {
+                const id = body?.id as string | undefined;
+                if (endpoint === '/api/filetree/getPathByID') {
+                    if (id === parentId) return { notebook: 'nb-1', path: `/${parentId}.sy` };
+                    if (id === existingId) return { notebook: 'nb-1', path: `/${parentId}/${existingId}.sy` };
+                    if (id === createdId) return { notebook: 'nb-1', path: `/${parentId}/${createdId}.sy` };
+                }
+                if (endpoint === '/api/filetree/getHPathByID') {
+                    if (id === parentId) return '/Imports';
+                    if (id === existingId) return '/Imports/Existing target';
+                    if (id === createdId) return '/Imports/New target';
+                }
+                if (endpoint === '/api/block/getDocInfo') {
+                    if (id === parentId) return { id, rootID: id, name: 'Imports' };
+                    if (id === existingId) return { id, rootID: id, name: 'Existing target' };
+                    if (id === createdId) return { id, rootID: id, name: 'New target' };
+                }
+                if (endpoint === '/api/filetree/listDocsByPath') {
+                    return { box: 'nb-1', path: `/${parentId}.sy`, files: children.map((child) => ({ ...child, box: 'nb-1' })) };
+                }
+                return null;
+            }),
+        } as never;
+        const permMgr = createMockPermissionManager({ canWrite: () => true });
+        permMgr.getAll = vi.fn(() => ({ 'nb-1': 'rw' }));
+        const coordinator = new WriteSafetyCoordinator(client);
+        const args = {
+            action: 'ensure_link_targets',
+            notebook: 'nb-1',
+            parentId,
+            mode: 'create',
+            targets: [{ key: 'new', title: 'New target' }],
+        };
+        const preflight = parseResult(await coordinator.run({
+            client, permMgr, category: 'document', action: 'ensure_link_targets',
+            args: { ...args, validateOnly: true }, strictMode: true, execute: vi.fn(),
+        }));
+        expect(preflight.preconditionField).toBe('expectedStructureHash');
+        expect(preflight.structureHash).toMatch(/^sha256:v1:/);
+
+        // A new sibling changes the full authority scope, so the create is
+        // stopped before dispatch rather than deciding by a title search.
+        children = [...children, { id: '20260813020104-child003', name: 'Concurrent target', path: `/${parentId}/20260813020104-child003.sy`, hPath: '/Imports/Concurrent target' }];
+        const blocked = parseResult(await coordinator.run({
+            client, permMgr, category: 'document', action: 'ensure_link_targets',
+            args: { ...args, requestId: uuidV7(Date.now(), '000000000041'), expectedStructureHash: preflight.structureHash },
+            strictMode: true, execute: vi.fn(),
+        }));
+        expect(blocked.error.code).toBe('state_changed');
+
+        const fresh = parseResult(await coordinator.run({
+            client, permMgr, category: 'document', action: 'ensure_link_targets',
+            args: { ...args, validateOnly: true }, strictMode: true, execute: vi.fn(),
+        }));
+        const execute = vi.fn(async () => {
+            children = [...children, { id: createdId, name: 'New target', path: `/${parentId}/${createdId}.sy`, hPath: '/Imports/New target' }];
+            return success({
+                success: true,
+                created: 1,
+                linkMap: { new: { id: createdId, notebook: 'nb-1', path: `/${parentId}/${createdId}.sy`, hPath: '/Imports/New target' } },
+            });
+        });
+        const requestId = uuidV7(Date.now(), '000000000042');
+        const committed = parseResult(await coordinator.run({
+            client, permMgr, category: 'document', action: 'ensure_link_targets',
+            args: { ...args, requestId, expectedStructureHash: fresh.structureHash },
+            strictMode: true, execute,
+        }));
+        expect(committed.safety).toMatchObject({ transactionState: 'committed', writeExecuted: true });
+        expect(execute).toHaveBeenCalledTimes(1);
+
+        const replayed = parseResult(await coordinator.run({
+            client, permMgr, category: 'document', action: 'ensure_link_targets',
+            args: { ...args, requestId, expectedStructureHash: fresh.structureHash },
+            strictMode: true, execute,
+        }));
+        expect(replayed.replayed).toBe(true);
+        expect(execute).toHaveBeenCalledTimes(1);
+
+        const unknownArgs = {
+            ...args,
+            targets: [{ key: 'unknown', title: 'Unknown target' }],
+        };
+        const unknownPreflight = parseResult(await coordinator.run({
+            client, permMgr, category: 'document', action: 'ensure_link_targets',
+            args: { ...unknownArgs, validateOnly: true }, strictMode: true, execute: vi.fn(),
+        }));
+        const uncertainExecute = vi.fn(async () => { throw new Error('connection dropped after create dispatch'); });
+        const unknownRequestId = uuidV7(Date.now(), '000000000043');
+        const unknown = parseResult(await coordinator.run({
+            client, permMgr, category: 'document', action: 'ensure_link_targets',
+            args: { ...unknownArgs, requestId: unknownRequestId, expectedStructureHash: unknownPreflight.structureHash },
+            strictMode: true, execute: uncertainExecute,
+        }));
+        expect(unknown).toMatchObject({
+            transactionState: 'unknown',
+            error: { code: 'outcome_unknown' },
+        });
+
+        const unknownReplay = parseResult(await coordinator.run({
+            client, permMgr, category: 'document', action: 'ensure_link_targets',
+            args: { ...unknownArgs, requestId: unknownRequestId, expectedStructureHash: unknownPreflight.structureHash },
+            strictMode: true, execute: uncertainExecute,
+        }));
+        expect(unknownReplay.error.code).toBe('outcome_unknown');
+        expect(uncertainExecute).toHaveBeenCalledTimes(1);
+    });
+
     it('observes timeline rollback changes through live document markdown', async () => {
         const documentID = '20260812000000-timeline';
         const blockID = '20260812000001-timeline';

--- a/tests/unit/core/write-safety-policy.test.ts
+++ b/tests/unit/core/write-safety-policy.test.ts
@@ -36,6 +36,12 @@ describe('write safety action policy', () => {
         expect(getActionSafetyPolicy('file', 'create_template', { overwrite: true })).toMatchObject({
             mode: 'mutation', precondition: 'state',
         });
+        expect(getActionSafetyPolicy('document', 'ensure_link_targets', { mode: 'resolve' })).toEqual({ mode: 'read' });
+        expect(getActionSafetyPolicy('document', 'ensure_link_targets', { mode: 'reuse' })).toEqual({ mode: 'read' });
+        expect(getActionSafetyPolicy('document', 'ensure_link_targets', { mode: 'create', dryRun: true })).toEqual({ mode: 'read' });
+        expect(getActionSafetyPolicy('document', 'ensure_link_targets', { mode: 'create' })).toMatchObject({
+            mode: 'mutation', precondition: 'structure',
+        });
         expect(getActionSafetyPolicy('extension', 'third_party_write')).toEqual({ mode: 'external' });
     });
 

--- a/tests/unit/tools/__snapshots__/help-output.snapshot.test.ts.snap
+++ b/tests/unit/tools/__snapshots__/help-output.snapshot.test.ts.snap
@@ -1354,6 +1354,7 @@ block(action="prepend") or block(action="append") with a document ID targets the
           "For document(action="lookup"), path means a storage path such as /20240318112233-abc123.sy; use hpath/hPath for human-readable paths such as /Inbox/Weekly Note.",
           "Other document actions that use notebook + path expect storage paths returned by document(action="lookup").",
           "If document(action="create") reports a duplicate-name error, verify the intended child with document(action="lookup", notebook=..., hpath="/Folder/Parent/New Child", include=["id","path","hpath"]) or document(action="get_child_docs", id=<parent-doc-id>). New create results may take a short indexing delay before lookup/search sees them.",
+          "document(action="ensure_link_targets") is the bounded import-link provisioner: scope it with notebook + parentId, reuse only explicit child document IDs, and use create only for explicit new titles. It never guesses an existing target from a title; same-title children are unresolved and require an ID decision.",
           "A safe path-based workflow is lookup -> rename/remove/move.",
           "document(action="get_child_blocks") and document(action="get_child_docs") return direct children for a document ID.",
           "document(action="set_attr") updates document metadata such as icon and cover; use attrs.cover=null or an empty string to clear the cover.",
@@ -1387,6 +1388,7 @@ block(action="prepend") or block(action="append") with a document ID targets the
           "For document(action="lookup"), path means a storage path such as /20240318112233-abc123.sy; use hpath/hPath for human-readable paths such as /Inbox/Weekly Note.",
           "Other document actions that use notebook + path expect storage paths returned by document(action="lookup").",
           "If document(action="create") reports a duplicate-name error, verify the intended child with document(action="lookup", notebook=..., hpath="/Folder/Parent/New Child", include=["id","path","hpath"]) or document(action="get_child_docs", id=<parent-doc-id>). New create results may take a short indexing delay before lookup/search sees them.",
+          "document(action="ensure_link_targets") is the bounded import-link provisioner: scope it with notebook + parentId, reuse only explicit child document IDs, and use create only for explicit new titles. It never guesses an existing target from a title; same-title children are unresolved and require an ID decision.",
           "A safe path-based workflow is lookup -> rename/remove/move.",
           "document(action="get_child_blocks") and document(action="get_child_docs") return direct children for a document ID.",
           "document(action="set_attr") updates document metadata such as icon and cover; use attrs.cover=null or an empty string to clear the cover.",
@@ -1421,6 +1423,7 @@ block(action="prepend") or block(action="append") with a document ID targets the
           "For document(action="lookup"), path means a storage path such as /20240318112233-abc123.sy; use hpath/hPath for human-readable paths such as /Inbox/Weekly Note.",
           "Other document actions that use notebook + path expect storage paths returned by document(action="lookup").",
           "If document(action="create") reports a duplicate-name error, verify the intended child with document(action="lookup", notebook=..., hpath="/Folder/Parent/New Child", include=["id","path","hpath"]) or document(action="get_child_docs", id=<parent-doc-id>). New create results may take a short indexing delay before lookup/search sees them.",
+          "document(action="ensure_link_targets") is the bounded import-link provisioner: scope it with notebook + parentId, reuse only explicit child document IDs, and use create only for explicit new titles. It never guesses an existing target from a title; same-title children are unresolved and require an ID decision.",
           "A safe path-based workflow is lookup -> rename/remove/move.",
           "document(action="get_child_blocks") and document(action="get_child_docs") return direct children for a document ID.",
           "document(action="set_attr") updates document metadata such as icon and cover; use attrs.cover=null or an empty string to clear the cover.",
@@ -1454,6 +1457,7 @@ block(action="prepend") or block(action="append") with a document ID targets the
           "For document(action="lookup"), path means a storage path such as /20240318112233-abc123.sy; use hpath/hPath for human-readable paths such as /Inbox/Weekly Note.",
           "Other document actions that use notebook + path expect storage paths returned by document(action="lookup").",
           "If document(action="create") reports a duplicate-name error, verify the intended child with document(action="lookup", notebook=..., hpath="/Folder/Parent/New Child", include=["id","path","hpath"]) or document(action="get_child_docs", id=<parent-doc-id>). New create results may take a short indexing delay before lookup/search sees them.",
+          "document(action="ensure_link_targets") is the bounded import-link provisioner: scope it with notebook + parentId, reuse only explicit child document IDs, and use create only for explicit new titles. It never guesses an existing target from a title; same-title children are unresolved and require an ID decision.",
           "A safe path-based workflow is lookup -> rename/remove/move.",
           "document(action="get_child_blocks") and document(action="get_child_docs") return direct children for a document ID.",
           "document(action="set_attr") updates document metadata such as icon and cover; use attrs.cover=null or an empty string to clear the cover.",
@@ -1467,6 +1471,50 @@ block(action="prepend") or block(action="append") with a document ID targets the
         "requiresConfirmation": false,
         "shapes": [
           "id",
+        ],
+        "tool": "document",
+      },
+      "ensure_link_targets": {
+        "action": "ensure_link_targets",
+        "example": {
+          "action": "ensure_link_targets",
+          "mode": "resolve",
+          "notebook": "20210808180117-czj9bvb",
+          "parentId": "<parentId>",
+          "targets": [
+            {
+              "key": "<key>",
+            },
+          ],
+        },
+        "fullDocResource": "siyuan://help/action/document/ensure_link_targets",
+        "guidance": [
+          "For ordinary document file operations, prefer fs(action="ls"|"tree"|"read"|"write"|"search") because it accepts human-readable paths and hides storage paths and IDs.",
+          "document(action="create") creates both non-empty and empty documents. Prefer path for child documents; path is a notebook-local human-readable hpath such as /Folder/Parent/New Child, not /Notebook/Folder/... and not a .sy storage path.",
+          "Do not put # Title at the start of document(action="create") markdown. SiYuan renders the document title as H1 automatically, and MCP strips a matching leading H1 to avoid duplicate titles.",
+          "document(action="create", parentPath=..., title=...) is also supported. parentPath accepts either a notebook-local human-readable parent hpath such as /Folder/Parent, or a storage path ending in .sy returned by document(action="lookup").",
+          "fs(action="write", path="/Notebook/Folder/Doc") uses a workspace path that includes the notebook name; document(action="create", notebook=..., path="/Folder/Doc") uses a notebook-local hpath. Do not mix these two path formats.",
+          "For document(action="lookup"), path means a storage path such as /20240318112233-abc123.sy; use hpath/hPath for human-readable paths such as /Inbox/Weekly Note.",
+          "Other document actions that use notebook + path expect storage paths returned by document(action="lookup").",
+          "If document(action="create") reports a duplicate-name error, verify the intended child with document(action="lookup", notebook=..., hpath="/Folder/Parent/New Child", include=["id","path","hpath"]) or document(action="get_child_docs", id=<parent-doc-id>). New create results may take a short indexing delay before lookup/search sees them.",
+          "document(action="ensure_link_targets") is the bounded import-link provisioner: scope it with notebook + parentId, reuse only explicit child document IDs, and use create only for explicit new titles. It never guesses an existing target from a title; same-title children are unresolved and require an ID decision.",
+          "A safe path-based workflow is lookup -> rename/remove/move.",
+          "document(action="get_child_blocks") and document(action="get_child_docs") return direct children for a document ID.",
+          "document(action="set_attr") updates document metadata such as icon and cover; use attrs.cover=null or an empty string to clear the cover.",
+          "document(action="search_docs") remains title-based, but MCP now post-filters results by notebook permission and optional storage path scope.",
+          "For recently created documents, document(action="lookup", hpath=...) may briefly lag behind create because it depends on SiYuan indexing; retry if needed.",
+          "document(action="lookup", id=...) may hit the same short indexing delay right after create; MCP retries briefly and then returns a timing-specific hint if indexing still has not settled.",
+        ],
+        "hint": "Scope every request with an explicit notebook ID and parent document ID. resolve/reuse require existing child document IDs and never fall back to titles. create accepts explicit new titles only; if a same-title child already exists, it is returned as unresolved rather than guessed or reused. dryRun performs zero writes only for create. resolve/reuse are read-only; create uses strict validateOnly preflight, then one commit with a fresh UUIDv7 requestId plus expectedStructureHash. Responses contain exact ID/path/HPath readback and resolved/created/reused/unresolved accounting.",
+        "requiredFields": [
+          "notebook",
+          "parentId",
+          "mode",
+          "targets",
+        ],
+        "requiresConfirmation": false,
+        "shapes": [
+          "notebook + parentId + mode + targets",
         ],
         "tool": "document",
       },
@@ -1486,6 +1534,7 @@ block(action="prepend") or block(action="append") with a document ID targets the
           "For document(action="lookup"), path means a storage path such as /20240318112233-abc123.sy; use hpath/hPath for human-readable paths such as /Inbox/Weekly Note.",
           "Other document actions that use notebook + path expect storage paths returned by document(action="lookup").",
           "If document(action="create") reports a duplicate-name error, verify the intended child with document(action="lookup", notebook=..., hpath="/Folder/Parent/New Child", include=["id","path","hpath"]) or document(action="get_child_docs", id=<parent-doc-id>). New create results may take a short indexing delay before lookup/search sees them.",
+          "document(action="ensure_link_targets") is the bounded import-link provisioner: scope it with notebook + parentId, reuse only explicit child document IDs, and use create only for explicit new titles. It never guesses an existing target from a title; same-title children are unresolved and require an ID decision.",
           "A safe path-based workflow is lookup -> rename/remove/move.",
           "document(action="get_child_blocks") and document(action="get_child_docs") return direct children for a document ID.",
           "document(action="set_attr") updates document metadata such as icon and cover; use attrs.cover=null or an empty string to clear the cover.",
@@ -1519,6 +1568,7 @@ block(action="prepend") or block(action="append") with a document ID targets the
           "For document(action="lookup"), path means a storage path such as /20240318112233-abc123.sy; use hpath/hPath for human-readable paths such as /Inbox/Weekly Note.",
           "Other document actions that use notebook + path expect storage paths returned by document(action="lookup").",
           "If document(action="create") reports a duplicate-name error, verify the intended child with document(action="lookup", notebook=..., hpath="/Folder/Parent/New Child", include=["id","path","hpath"]) or document(action="get_child_docs", id=<parent-doc-id>). New create results may take a short indexing delay before lookup/search sees them.",
+          "document(action="ensure_link_targets") is the bounded import-link provisioner: scope it with notebook + parentId, reuse only explicit child document IDs, and use create only for explicit new titles. It never guesses an existing target from a title; same-title children are unresolved and require an ID decision.",
           "A safe path-based workflow is lookup -> rename/remove/move.",
           "document(action="get_child_blocks") and document(action="get_child_docs") return direct children for a document ID.",
           "document(action="set_attr") updates document metadata such as icon and cover; use attrs.cover=null or an empty string to clear the cover.",
@@ -1552,6 +1602,7 @@ block(action="prepend") or block(action="append") with a document ID targets the
           "For document(action="lookup"), path means a storage path such as /20240318112233-abc123.sy; use hpath/hPath for human-readable paths such as /Inbox/Weekly Note.",
           "Other document actions that use notebook + path expect storage paths returned by document(action="lookup").",
           "If document(action="create") reports a duplicate-name error, verify the intended child with document(action="lookup", notebook=..., hpath="/Folder/Parent/New Child", include=["id","path","hpath"]) or document(action="get_child_docs", id=<parent-doc-id>). New create results may take a short indexing delay before lookup/search sees them.",
+          "document(action="ensure_link_targets") is the bounded import-link provisioner: scope it with notebook + parentId, reuse only explicit child document IDs, and use create only for explicit new titles. It never guesses an existing target from a title; same-title children are unresolved and require an ID decision.",
           "A safe path-based workflow is lookup -> rename/remove/move.",
           "document(action="get_child_blocks") and document(action="get_child_docs") return direct children for a document ID.",
           "document(action="set_attr") updates document metadata such as icon and cover; use attrs.cover=null or an empty string to clear the cover.",
@@ -1585,6 +1636,7 @@ block(action="prepend") or block(action="append") with a document ID targets the
           "For document(action="lookup"), path means a storage path such as /20240318112233-abc123.sy; use hpath/hPath for human-readable paths such as /Inbox/Weekly Note.",
           "Other document actions that use notebook + path expect storage paths returned by document(action="lookup").",
           "If document(action="create") reports a duplicate-name error, verify the intended child with document(action="lookup", notebook=..., hpath="/Folder/Parent/New Child", include=["id","path","hpath"]) or document(action="get_child_docs", id=<parent-doc-id>). New create results may take a short indexing delay before lookup/search sees them.",
+          "document(action="ensure_link_targets") is the bounded import-link provisioner: scope it with notebook + parentId, reuse only explicit child document IDs, and use create only for explicit new titles. It never guesses an existing target from a title; same-title children are unresolved and require an ID decision.",
           "A safe path-based workflow is lookup -> rename/remove/move.",
           "document(action="get_child_blocks") and document(action="get_child_docs") return direct children for a document ID.",
           "document(action="set_attr") updates document metadata such as icon and cover; use attrs.cover=null or an empty string to clear the cover.",
@@ -1619,6 +1671,7 @@ block(action="prepend") or block(action="append") with a document ID targets the
           "For document(action="lookup"), path means a storage path such as /20240318112233-abc123.sy; use hpath/hPath for human-readable paths such as /Inbox/Weekly Note.",
           "Other document actions that use notebook + path expect storage paths returned by document(action="lookup").",
           "If document(action="create") reports a duplicate-name error, verify the intended child with document(action="lookup", notebook=..., hpath="/Folder/Parent/New Child", include=["id","path","hpath"]) or document(action="get_child_docs", id=<parent-doc-id>). New create results may take a short indexing delay before lookup/search sees them.",
+          "document(action="ensure_link_targets") is the bounded import-link provisioner: scope it with notebook + parentId, reuse only explicit child document IDs, and use create only for explicit new titles. It never guesses an existing target from a title; same-title children are unresolved and require an ID decision.",
           "A safe path-based workflow is lookup -> rename/remove/move.",
           "document(action="get_child_blocks") and document(action="get_child_docs") return direct children for a document ID.",
           "document(action="set_attr") updates document metadata such as icon and cover; use attrs.cover=null or an empty string to clear the cover.",
@@ -1653,6 +1706,7 @@ block(action="prepend") or block(action="append") with a document ID targets the
           "For document(action="lookup"), path means a storage path such as /20240318112233-abc123.sy; use hpath/hPath for human-readable paths such as /Inbox/Weekly Note.",
           "Other document actions that use notebook + path expect storage paths returned by document(action="lookup").",
           "If document(action="create") reports a duplicate-name error, verify the intended child with document(action="lookup", notebook=..., hpath="/Folder/Parent/New Child", include=["id","path","hpath"]) or document(action="get_child_docs", id=<parent-doc-id>). New create results may take a short indexing delay before lookup/search sees them.",
+          "document(action="ensure_link_targets") is the bounded import-link provisioner: scope it with notebook + parentId, reuse only explicit child document IDs, and use create only for explicit new titles. It never guesses an existing target from a title; same-title children are unresolved and require an ID decision.",
           "A safe path-based workflow is lookup -> rename/remove/move.",
           "document(action="get_child_blocks") and document(action="get_child_docs") return direct children for a document ID.",
           "document(action="set_attr") updates document metadata such as icon and cover; use attrs.cover=null or an empty string to clear the cover.",
@@ -1686,6 +1740,7 @@ block(action="prepend") or block(action="append") with a document ID targets the
           "For document(action="lookup"), path means a storage path such as /20240318112233-abc123.sy; use hpath/hPath for human-readable paths such as /Inbox/Weekly Note.",
           "Other document actions that use notebook + path expect storage paths returned by document(action="lookup").",
           "If document(action="create") reports a duplicate-name error, verify the intended child with document(action="lookup", notebook=..., hpath="/Folder/Parent/New Child", include=["id","path","hpath"]) or document(action="get_child_docs", id=<parent-doc-id>). New create results may take a short indexing delay before lookup/search sees them.",
+          "document(action="ensure_link_targets") is the bounded import-link provisioner: scope it with notebook + parentId, reuse only explicit child document IDs, and use create only for explicit new titles. It never guesses an existing target from a title; same-title children are unresolved and require an ID decision.",
           "A safe path-based workflow is lookup -> rename/remove/move.",
           "document(action="get_child_blocks") and document(action="get_child_docs") return direct children for a document ID.",
           "document(action="set_attr") updates document metadata such as icon and cover; use attrs.cover=null or an empty string to clear the cover.",
@@ -1716,6 +1771,7 @@ block(action="prepend") or block(action="append") with a document ID targets the
           "For document(action="lookup"), path means a storage path such as /20240318112233-abc123.sy; use hpath/hPath for human-readable paths such as /Inbox/Weekly Note.",
           "Other document actions that use notebook + path expect storage paths returned by document(action="lookup").",
           "If document(action="create") reports a duplicate-name error, verify the intended child with document(action="lookup", notebook=..., hpath="/Folder/Parent/New Child", include=["id","path","hpath"]) or document(action="get_child_docs", id=<parent-doc-id>). New create results may take a short indexing delay before lookup/search sees them.",
+          "document(action="ensure_link_targets") is the bounded import-link provisioner: scope it with notebook + parentId, reuse only explicit child document IDs, and use create only for explicit new titles. It never guesses an existing target from a title; same-title children are unresolved and require an ID decision.",
           "A safe path-based workflow is lookup -> rename/remove/move.",
           "document(action="get_child_blocks") and document(action="get_child_docs") return direct children for a document ID.",
           "document(action="set_attr") updates document metadata such as icon and cover; use attrs.cover=null or an empty string to clear the cover.",
@@ -1746,6 +1802,7 @@ block(action="prepend") or block(action="append") with a document ID targets the
           "For document(action="lookup"), path means a storage path such as /20240318112233-abc123.sy; use hpath/hPath for human-readable paths such as /Inbox/Weekly Note.",
           "Other document actions that use notebook + path expect storage paths returned by document(action="lookup").",
           "If document(action="create") reports a duplicate-name error, verify the intended child with document(action="lookup", notebook=..., hpath="/Folder/Parent/New Child", include=["id","path","hpath"]) or document(action="get_child_docs", id=<parent-doc-id>). New create results may take a short indexing delay before lookup/search sees them.",
+          "document(action="ensure_link_targets") is the bounded import-link provisioner: scope it with notebook + parentId, reuse only explicit child document IDs, and use create only for explicit new titles. It never guesses an existing target from a title; same-title children are unresolved and require an ID decision.",
           "A safe path-based workflow is lookup -> rename/remove/move.",
           "document(action="get_child_blocks") and document(action="get_child_docs") return direct children for a document ID.",
           "document(action="set_attr") updates document metadata such as icon and cover; use attrs.cover=null or an empty string to clear the cover.",
@@ -1777,6 +1834,7 @@ block(action="prepend") or block(action="append") with a document ID targets the
           "For document(action="lookup"), path means a storage path such as /20240318112233-abc123.sy; use hpath/hPath for human-readable paths such as /Inbox/Weekly Note.",
           "Other document actions that use notebook + path expect storage paths returned by document(action="lookup").",
           "If document(action="create") reports a duplicate-name error, verify the intended child with document(action="lookup", notebook=..., hpath="/Folder/Parent/New Child", include=["id","path","hpath"]) or document(action="get_child_docs", id=<parent-doc-id>). New create results may take a short indexing delay before lookup/search sees them.",
+          "document(action="ensure_link_targets") is the bounded import-link provisioner: scope it with notebook + parentId, reuse only explicit child document IDs, and use create only for explicit new titles. It never guesses an existing target from a title; same-title children are unresolved and require an ID decision.",
           "A safe path-based workflow is lookup -> rename/remove/move.",
           "document(action="get_child_blocks") and document(action="get_child_docs") return direct children for a document ID.",
           "document(action="set_attr") updates document metadata such as icon and cover; use attrs.cover=null or an empty string to clear the cover.",
@@ -1811,6 +1869,7 @@ block(action="prepend") or block(action="append") with a document ID targets the
           "For document(action="lookup"), path means a storage path such as /20240318112233-abc123.sy; use hpath/hPath for human-readable paths such as /Inbox/Weekly Note.",
           "Other document actions that use notebook + path expect storage paths returned by document(action="lookup").",
           "If document(action="create") reports a duplicate-name error, verify the intended child with document(action="lookup", notebook=..., hpath="/Folder/Parent/New Child", include=["id","path","hpath"]) or document(action="get_child_docs", id=<parent-doc-id>). New create results may take a short indexing delay before lookup/search sees them.",
+          "document(action="ensure_link_targets") is the bounded import-link provisioner: scope it with notebook + parentId, reuse only explicit child document IDs, and use create only for explicit new titles. It never guesses an existing target from a title; same-title children are unresolved and require an ID decision.",
           "A safe path-based workflow is lookup -> rename/remove/move.",
           "document(action="get_child_blocks") and document(action="get_child_docs") return direct children for a document ID.",
           "document(action="set_attr") updates document metadata such as icon and cover; use attrs.cover=null or an empty string to clear the cover.",
@@ -1848,6 +1907,7 @@ block(action="prepend") or block(action="append") with a document ID targets the
           "For document(action="lookup"), path means a storage path such as /20240318112233-abc123.sy; use hpath/hPath for human-readable paths such as /Inbox/Weekly Note.",
           "Other document actions that use notebook + path expect storage paths returned by document(action="lookup").",
           "If document(action="create") reports a duplicate-name error, verify the intended child with document(action="lookup", notebook=..., hpath="/Folder/Parent/New Child", include=["id","path","hpath"]) or document(action="get_child_docs", id=<parent-doc-id>). New create results may take a short indexing delay before lookup/search sees them.",
+          "document(action="ensure_link_targets") is the bounded import-link provisioner: scope it with notebook + parentId, reuse only explicit child document IDs, and use create only for explicit new titles. It never guesses an existing target from a title; same-title children are unresolved and require an ID decision.",
           "A safe path-based workflow is lookup -> rename/remove/move.",
           "document(action="get_child_blocks") and document(action="get_child_docs") return direct children for a document ID.",
           "document(action="set_attr") updates document metadata such as icon and cover; use attrs.cover=null or an empty string to clear the cover.",
@@ -1871,11 +1931,12 @@ block(action="prepend") or block(action="append") with a document ID targets the
 
 Common actions: create, lookup, rename, get_child_blocks, get_child_docs, search_docs, get_doc, get_outline. Required fields: create: notebook; lookup: no additional fields; rename: title; get_child_blocks: id; get_child_docs: id; search_docs: notebook, query; get_doc: id; get_outline: id.
 
-Additional actions: remove, move, set_attr, list_tree, create_daily_note, duplicate, heading_to_doc, doc_to_heading. Read siyuan://help/action/document/{action} for details, or call action="help" if resources are unavailable.
+Additional actions: ensure_link_targets, remove, move, set_attr, list_tree, create_daily_note, duplicate, heading_to_doc, doc_to_heading. Read siyuan://help/action/document/{action} for details, or call action="help" if resources are unavailable.
 
 Parameter contract per action (fields outside the action's optional list should not be sent):
 document.create: required [notebook] | optional [path, parentPath, title, markdown, sorts, icon]
 document.lookup: required [] | optional [id, notebook, path, hpath, hPath, include]
+document.ensure_link_targets: required [notebook, parentId, mode, targets] | optional [markdown, dryRun]
 document.rename: required [title] | optional [id, notebook, path]
 document.remove: required [] | optional [ids, paths, id, notebook, path]
 document.move: required [] | optional [fromPaths, toNotebook, toPath, fromIDs, toID]
@@ -1898,6 +1959,7 @@ For ordinary document file operations, prefer fs(action="ls"|"tree"|"read"|"writ
         "create_daily_note": "Use a notebook ID and optionally pass app for downstream SiYuan event routing. When the user asks for a diary, journal entry, daily log, or today’s note in a notebook, prefer this action over manually creating a path and then appending content.",
         "doc_to_heading": "requires: srcID, targetID",
         "duplicate": "requires: id",
+        "ensure_link_targets": "Scope every request with an explicit notebook ID and parent document ID. resolve/reuse require existing child document IDs and never fall back to titles. create accepts explicit new titles only; if a same-title child already exists, it is returned as unresolved rather than guessed or reused. dryRun performs zero writes only for create. resolve/reuse are read-only; create uses strict validateOnly preflight, then one commit with a fresh UUIDv7 requestId plus expectedStructureHash. Responses contain exact ID/path/HPath readback and resolved/created/reused/unresolved accounting.",
         "get_child_blocks": "Use a document ID. Returns direct child blocks only.",
         "get_child_docs": "Use a document ID. Returns direct child documents only.",
         "get_doc": "Use a document ID. mode="markdown" returns clean Markdown in complete display-block windows with outline, token budget, and nextWindow metadata; use blockStart/blockLimit/tokenBudget and optionally includeBlockIds. page/pageSize character pagination was removed. mode="html" uses the current focus view.",
@@ -1924,6 +1986,10 @@ For ordinary document file operations, prefer fs(action="ls"|"tree"|"read"|"writ
           "requiresConfirmation": false,
         },
         "duplicate": {
+          "requiresConfirmation": false,
+        },
+        "ensure_link_targets": {
+          "hint": "Scope every request with an explicit notebook ID and parent document ID. resolve/reuse require existing child document IDs and never fall back to titles. create accepts explicit new titles only; if a same-title child already exists, it is returned as unresolved rather than guessed or reused. dryRun performs zero writes only for create. resolve/reuse are read-only; create uses strict validateOnly preflight, then one commit with a fresh UUIDv7 requestId plus expectedStructureHash. Responses contain exact ID/path/HPath readback and resolved/created/reused/unresolved accounting.",
           "requiresConfirmation": false,
         },
         "get_child_blocks": {
@@ -1975,6 +2041,7 @@ For ordinary document file operations, prefer fs(action="ls"|"tree"|"read"|"writ
         },
       },
       "advancedActions": [
+        "ensure_link_targets",
         "remove",
         "move",
         "set_attr",
@@ -2004,6 +2071,7 @@ For ordinary document file operations, prefer fs(action="ls"|"tree"|"read"|"writ
         "For document(action="lookup"), path means a storage path such as /20240318112233-abc123.sy; use hpath/hPath for human-readable paths such as /Inbox/Weekly Note.",
         "Other document actions that use notebook + path expect storage paths returned by document(action="lookup").",
         "If document(action="create") reports a duplicate-name error, verify the intended child with document(action="lookup", notebook=..., hpath="/Folder/Parent/New Child", include=["id","path","hpath"]) or document(action="get_child_docs", id=<parent-doc-id>). New create results may take a short indexing delay before lookup/search sees them.",
+        "document(action="ensure_link_targets") is the bounded import-link provisioner: scope it with notebook + parentId, reuse only explicit child document IDs, and use create only for explicit new titles. It never guesses an existing target from a title; same-title children are unresolved and require an ID decision.",
         "A safe path-based workflow is lookup -> rename/remove/move.",
         "document(action="get_child_blocks") and document(action="get_child_docs") return direct children for a document ID.",
         "document(action="set_attr") updates document metadata such as icon and cover; use attrs.cover=null or an empty string to clear the cover.",

--- a/tests/unit/tools/action-contract.test.ts
+++ b/tests/unit/tools/action-contract.test.ts
@@ -100,6 +100,7 @@ function createContractClient() {
                 return [];
             }
             if (endpoint === '/api/block/getBlockInfo') return { id: body?.id, rootID: 'doc-1' };
+            if (endpoint === '/api/block/getDocInfo') return { id: body?.id, rootID: body?.id, name: 'Doc 1' };
             if (endpoint === '/api/block/getBlockBreadcrumb') return [{ id: 'doc-1', name: 'Doc' }];
             if (endpoint === '/api/block/getBlockDOM') return { id: body?.id as string, dom: '<p>content</p>' };
             if (endpoint === '/api/block/getRecentUpdatedBlocks') return [{ id: 'block-1', rootID: 'doc-1', box: 'nb-1', path: '/doc-1.sy', type: 'p' }];
@@ -218,6 +219,7 @@ describe('tool action contract coverage', () => {
         await runContracts('document', DOCUMENT_VARIANTS, callDocumentTool as ToolCaller, [
             { action: 'create', args: { action: 'create', notebook: 'nb-1', path: '/Doc', markdown: 'hello' }, expectedEndpoint: '/api/filetree/createDocWithMd' },
             { action: 'lookup', args: { action: 'lookup', id: 'doc-1' }, expectedEndpoint: '/api/filetree/getPathByID' },
+            { action: 'ensure_link_targets', args: { action: 'ensure_link_targets', notebook: 'nb-1', parentId: 'doc-1', mode: 'resolve', targets: [{ key: 'parent', id: 'doc-1' }] }, expectedEndpoint: '/api/filetree/listDocsByPath' },
             { action: 'rename', args: { action: 'rename', id: 'doc-1', title: 'Renamed' }, expectedEndpoint: '/api/filetree/renameDocByID' },
             { action: 'remove', args: { action: 'remove', id: 'doc-1' }, expectedEndpoint: '/api/filetree/removeDocByID' },
             { action: 'move', args: { action: 'move', fromIDs: ['doc-1'], toID: 'doc-parent' }, expectedEndpoint: '/api/filetree/moveDocsByID' },

--- a/tests/unit/tools/document.test.ts
+++ b/tests/unit/tools/document.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { buildDefaultToolConfig } from '@/core/config';
-import { DocumentMoveSchema } from '@/core/types';
+import { DocumentEnsureLinkTargetsSchema, DocumentMoveSchema } from '@/core/types';
 import { callDocumentTool, DOCUMENT_VARIANTS, listDocumentTools } from '@/tools/document';
 import { createMockClient } from '../../helpers/mock-client';
 import { parseResult } from '../../helpers/parse-result';
@@ -20,6 +20,171 @@ describe('document tool extended actions', () => {
         expect(actionDescription).toContain('heading_to_doc');
         expect(actionDescription).toContain('doc_to_heading');
         expect(actionDescription).toContain('get_outline');
+        expect(actionDescription).toContain('ensure_link_targets');
+    });
+});
+
+describe('document.ensure_link_targets', () => {
+    const parentId = '20260813010101-parent01';
+    const existingId = '20260813010102-child001';
+    const createdId = '20260813010103-child002';
+
+    function createScopedClient(options: { existingName?: string; createId?: string } = {}) {
+        const existingName = options.existingName ?? 'Existing target';
+        let client: ReturnType<typeof createMockClient>;
+        client = createMockClient({
+            request: vi.fn(async (endpoint: string, body?: Record<string, unknown>) => {
+                const id = body?.id as string | undefined;
+                if (endpoint === '/api/filetree/getPathByID') {
+                    if (id === parentId) return { notebook: 'nb-1', path: `/${parentId}.sy` };
+                    if (id === existingId) return { notebook: 'nb-1', path: `/${parentId}/${existingId}.sy` };
+                    if (id === createdId) return { notebook: 'nb-1', path: `/${parentId}/${createdId}.sy` };
+                }
+                if (endpoint === '/api/filetree/getHPathByID') {
+                    if (id === parentId) return '/Imports';
+                    if (id === existingId) return '/Imports/Existing target';
+                    if (id === createdId) return '/Imports/New target';
+                }
+                if (endpoint === '/api/block/getDocInfo') {
+                    if (id === parentId) return { id, rootID: id, name: 'Imports' };
+                    if (id === existingId) return { id, rootID: id, name: existingName };
+                    if (id === createdId) return { id, rootID: id, name: 'New target' };
+                }
+                if (endpoint === '/api/filetree/listDocsByPath') {
+                    expect(body).toEqual({ notebook: 'nb-1', path: `/${parentId}.sy` });
+                    const files = [{ id: existingId, box: 'nb-1', path: `/${parentId}/${existingId}.sy`, name: `${existingName}.sy`, hPath: `/Imports/${existingName}` }];
+                    if (options.createId && body?.path === `/${parentId}.sy`) {
+                        // The action reads scope before and after creation. The mock
+                        // reveals the new ID only after the API create endpoint runs.
+                        const created = (client.request as ReturnType<typeof vi.fn>).mock.calls.some(([called]) => called === '/api/filetree/createDocWithMd');
+                        if (created) files.push({ id: createdId, box: 'nb-1', path: `/${parentId}/${createdId}.sy`, name: 'New target.sy', hPath: '/Imports/New target' });
+                    }
+                    return { box: 'nb-1', path: `/${parentId}.sy`, files };
+                }
+                if (endpoint === '/api/filetree/createDocWithMd') {
+                    expect(body).toEqual({ notebook: 'nb-1', path: '/Imports/New target', markdown: 'seed' });
+                    return options.createId ?? createdId;
+                }
+                if (endpoint.startsWith('/api/ui/')) return null;
+                throw new Error(`Unexpected endpoint: ${endpoint}`);
+            }),
+        });
+        return client;
+    }
+
+    const writablePermMgr = {
+        reload: vi.fn(async () => undefined),
+        canRead: vi.fn(() => true),
+        canWrite: vi.fn(() => true),
+        get: vi.fn(() => 'rwd'),
+    };
+    const readOnlyPermMgr = {
+        reload: vi.fn(async () => undefined),
+        canRead: vi.fn(() => true),
+        canWrite: vi.fn(() => false),
+        get: vi.fn(() => 'r'),
+    };
+
+    it('resolves only an explicit direct-child ID and returns exact identity readback', async () => {
+        const client = createScopedClient();
+        const result = await callDocumentTool(
+            client,
+            { action: 'ensure_link_targets', notebook: 'nb-1', parentId, mode: 'resolve', targets: [{ key: 'existing', id: existingId }] },
+            buildDefaultToolConfig().document,
+            writablePermMgr as never,
+        );
+
+        expect(parseResult(result)).toMatchObject({
+            success: true,
+            createdCount: 0,
+            resolvedCount: 1,
+            unresolvedCount: 0,
+            resolved: [{ key: 'existing', disposition: 'resolved', id: existingId }],
+            linkMap: {
+                existing: {
+                    id: existingId,
+                    notebook: 'nb-1',
+                    path: `/${parentId}/${existingId}.sy`,
+                    hPath: '/Imports/Existing target',
+                },
+            },
+        });
+        expect(client.request).not.toHaveBeenCalledWith('/api/filetree/createDocWithMd', expect.anything());
+    });
+
+    it('returns a reused exact child ID with read-only permission and never writes', async () => {
+        const client = createScopedClient();
+        const result = await callDocumentTool(
+            client,
+            { action: 'ensure_link_targets', notebook: 'nb-1', parentId, mode: 'reuse', targets: [{ key: 'existing', id: existingId }] },
+            buildDefaultToolConfig().document,
+            readOnlyPermMgr as never,
+        );
+
+        expect(parseResult(result)).toMatchObject({
+            success: true,
+            reusedCount: 1,
+            reused: [{ key: 'existing', disposition: 'reused', id: existingId }],
+            unresolvedCount: 0,
+        });
+        expect(client.request).not.toHaveBeenCalledWith('/api/filetree/createDocWithMd', expect.anything());
+    });
+
+    it('does not reuse a same-title child during create dry-run', async () => {
+        const client = createScopedClient({ existingName: 'New target' });
+        const result = await callDocumentTool(
+            client,
+            { action: 'ensure_link_targets', notebook: 'nb-1', parentId, mode: 'create', dryRun: true, targets: [{ key: 'new', title: 'New target' }] },
+            buildDefaultToolConfig().document,
+            readOnlyPermMgr as never,
+        );
+
+        expect(parseResult(result)).toMatchObject({
+            success: false,
+            dryRun: true,
+            created: [],
+            unresolved: [{ key: 'new', title: 'New target', reason: 'same_title_child_requires_explicit_id' }],
+        });
+        expect(client.request).not.toHaveBeenCalledWith('/api/filetree/createDocWithMd', expect.anything());
+    });
+
+    it('creates only explicit missing children and then reads the exact created ID back', async () => {
+        const client = createScopedClient({ createId: createdId });
+        const result = await callDocumentTool(
+            client,
+            { action: 'ensure_link_targets', notebook: 'nb-1', parentId, mode: 'create', markdown: 'seed', targets: [{ key: 'new', title: 'New target' }] },
+            buildDefaultToolConfig().document,
+            writablePermMgr as never,
+        );
+
+        expect(parseResult(result)).toMatchObject({
+            success: true,
+            createdCount: 1,
+            reusedCount: 0,
+            unresolvedCount: 0,
+            created: [{
+                key: 'new',
+                disposition: 'created',
+                id: createdId,
+                notebook: 'nb-1',
+                path: `/${parentId}/${createdId}.sy`,
+                hPath: '/Imports/New target',
+            }],
+        });
+    });
+
+    it('rejects title-based resolve/reuse input and duplicate create titles before any API call', () => {
+        expect(DocumentEnsureLinkTargetsSchema.safeParse({
+            action: 'ensure_link_targets', notebook: 'nb-1', parentId, mode: 'resolve', targets: [{ key: 'wrong', title: 'Existing target' }],
+        }).success).toBe(false);
+        expect(DocumentEnsureLinkTargetsSchema.safeParse({
+            action: 'ensure_link_targets', notebook: 'nb-1', parentId, mode: 'create', targets: [
+                { key: 'a', title: 'Same' }, { key: 'b', title: 'Same' },
+            ],
+        }).success).toBe(false);
+        expect(DocumentEnsureLinkTargetsSchema.safeParse({
+            action: 'ensure_link_targets', notebook: 'nb-1', parentId, mode: 'reuse', dryRun: true, targets: [{ key: 'existing', id: existingId }],
+        }).success).toBe(false);
     });
 });
 


### PR DESCRIPTION
## 为什么要改

导入或迁移在建立动态链接时，不能把标题、搜索结果或页面位置当作目标身份。现有 document aggregate 缺少一个能把明确范围、精确 ID、创建读回、幂等写入一起表达的入口，因此同名子文档容易被错误复用，响应丢失后也缺少安全的继续规则。

## 做了什么

- 新增 document.ensure_link_targets。每个请求都必须显式给出 notebook + parentId，范围只包括该父文档的直属子文档；既有目标只能给精确 ID，绝不按标题猜测。
- resolve、reuse 与 create(dryRun=true) 均为只读：前两者分别返回 resolved / reused，dry-run 只返回 wouldCreate。同名直属子文档一律返回 unresolved，不会隐式复用。
- 实际 create 走严格结构预检：先 validateOnly=true 取得 expectedStructureHash，再用新的 UUIDv7 requestId 单次提交。预检后直属子列表变化会拒绝提交；同一 requestId 重放不会再次写入。
- 创建后强制读回每个结果的精确 id/notebook/path/hPath；未知响应或读回不一致不会自动重试。action 不自动删除文档，任何清理都必须另行授权并指定精确 ID。
- 同步 config、类型、write-safety policy/coordinator、MCP/CLI help、双语文档、i18n、API mapping 与回归测试。

## 验证

- npm test：94 个测试文件、1060 个测试通过。
- npm run build、npm run build:cli、npm run docs:build、npm run skills:check 与 git diff --check 均通过。
- FLO.W 临时 live 验证仅授予该 notebook rw：完成 validateOnly 与实际 create、精确 ID/path/hPath 读回、相同 requestId replay 零写、按精确 ID 清理；权限文件已恢复为 404/默认 r，正式插件状态未改变。
- 同名目标拒绝，任何未经授权的范围均未写入。