### PR TITLE
fix🐛(av): av.render 读取内核 view.rows 并修正 cell/分组/分页语义

### DIFF
--- a/src/tools/av/handlers.ts
+++ b/src/tools/av/handlers.ts
@@ -1173,16 +1173,29 @@ async function handleRender({ client, permMgr, rawArgs }: ToolHandlerContext): P
     const responseObj = (response && typeof response === 'object' && !Array.isArray(response))
         ? response as Record<string, unknown>
         : {};
-    const rows = Array.isArray(responseObj.rows) ? responseObj.rows as unknown[] : [];
+    // SiYuan kernel nests the rendered view (columns/rows/rowCount) under `view`;
+    // fall back to flat top-level fields for older kernel response shapes.
+    const view = (responseObj.view && typeof responseObj.view === 'object' && !Array.isArray(responseObj.view))
+        ? responseObj.view as Record<string, unknown>
+        : undefined;
+    const rows = (
+        Array.isArray(view?.rows) ? view.rows
+            : Array.isArray(responseObj.rows) ? responseObj.rows
+                : []
+    ) as unknown[];
     const page = parsed.page ?? 1;
     const pageSize = parsed.pageSize ?? (rows.length || 1);
-    const kernelPageCount = typeof responseObj.pageCount === 'number'
-        ? responseObj.pageCount as number
-        : 1;
-    const total = typeof responseObj.rowCount === 'number'
-        ? responseObj.rowCount as number
-        : rows.length;
-    const table = buildAvTableView(responseObj, rows, total);
+    const total = typeof view?.rowCount === 'number'
+        ? view.rowCount as number
+        : typeof responseObj.rowCount === 'number'
+            ? responseObj.rowCount as number
+            : rows.length;
+    const kernelPageCount = typeof view?.pageCount === 'number'
+        ? view.pageCount as number
+        : typeof responseObj.pageCount === 'number'
+            ? responseObj.pageCount as number
+            : pageSize > 0 ? Math.max(1, Math.ceil(total / pageSize)) : 1;
+    const table = buildAvTableView(view ?? responseObj, rows, total);
     const { rows: _ignoredRows, pageCount: _ignoredPageCount, rowCount: _ignoredRowCount, ...restResponse } = responseObj;
     void _ignoredRows;
     void _ignoredPageCount;

--- a/src/tools/av/handlers.ts
+++ b/src/tools/av/handlers.ts
@@ -21,6 +21,7 @@ import {
     AvSetCellsSchema,
 } from '../../core/types';
 import { createResultResolutionCache, ensurePermissionForDocumentId, escapeSqlString, resolveDocumentContextById, resolveResultItemContext } from '../internal/context';
+import { computePageCount } from '../internal/pagination';
 import type { ToolActionHandler, ToolHandlerContext } from '../internal/define-tool';
 import { isMissingBlockError, translateError } from '../internal/errorTranslation';
 import { createJsonResult, createPaginatedResult, createWriteSuccessResult, type ToolResult } from '../internal/shared';
@@ -846,8 +847,21 @@ function pickString(record: Record<string, unknown>, keys: string[]): string | u
 function normalizeAvValue(value: unknown): unknown {
     if (!value || typeof value !== 'object' || Array.isArray(value)) return value;
     const record = value as Record<string, unknown>;
-    for (const key of ['content', 'text', 'number', 'isChecked', 'date', 'mSelect', 'select', 'block']) {
-        if (key in record) return record[key];
+    // 内核 Value 对象的内容在类型子对象里：text/number/date 等标量类解包出
+    // content/checked，多值/引用类（mSelect/relation/block 等）原样返回
+    for (const key of ['text', 'number', 'date', 'url', 'email', 'phone', 'template', 'created', 'updated', 'checkbox']) {
+        const sub = record[key];
+        if (sub !== undefined && sub !== null) {
+            if (typeof sub === 'object' && !Array.isArray(sub)) {
+                const subRecord = sub as Record<string, unknown>;
+                if ('content' in subRecord) return subRecord.content;
+                if ('checked' in subRecord) return subRecord.checked;
+            }
+            return sub;
+        }
+    }
+    for (const key of ['mSelect', 'select', 'block', 'relation', 'rollup', 'mAsset']) {
+        if (record[key] !== undefined && record[key] !== null) return record[key];
     }
     return value;
 }
@@ -886,17 +900,64 @@ function extractAvTableRows(rows: unknown[]): AvTableView['rows'] {
         for (const value of values) {
             if (!value || typeof value !== 'object' || Array.isArray(value)) continue;
             const cell = value as Record<string, unknown>;
+            // 内核渲染 cell：{ id: 值ID, value: { keyID: 列ID, ... }, valueType }，
+            // 顶层 id 是值 ID 而非列 ID，列 keyID 必须从 value.keyID 取
+            const inner = cell.value && typeof cell.value === 'object' && !Array.isArray(cell.value)
+                ? cell.value as Record<string, unknown>
+                : undefined;
             const keyObj = cell.key && typeof cell.key === 'object' && !Array.isArray(cell.key)
                 ? cell.key as Record<string, unknown>
                 : {};
-            const columnID = pickString(cell, ['keyID', 'columnID', 'id']) ?? pickString(keyObj, ['id', 'keyID']);
+            const columnID = (inner ? pickString(inner, ['keyID']) : undefined)
+                ?? pickString(keyObj, ['id', 'keyID'])
+                ?? pickString(cell, ['keyID', 'columnID'])
+                ?? pickString(cell, ['id']);
             if (!columnID) continue;
-            cells[columnID] = normalizeAvValue(cell);
+            cells[columnID] = normalizeAvValue(inner ?? cell);
         }
         if (Object.keys(cells).length === 0) return [];
         const id = pickString(record, ['id', 'rowID', 'blockID']);
         return [{ ...(id ? { id } : {}), cells }];
     });
+}
+
+function extractViewItems(view: Record<string, unknown> | undefined): { items: unknown[]; total: number } {
+    if (!view) return { items: [], total: 0 };
+    const rows = Array.isArray(view.rows) ? view.rows
+        : Array.isArray(view.cards) ? view.cards
+            : [];
+    const total = typeof view.rowCount === 'number' ? view.rowCount as number
+        : typeof view.cardCount === 'number' ? view.cardCount as number
+            : rows.length;
+    if (rows.length > 0 || !Array.isArray(view.groups)) return { items: rows, total };
+    // 分组视图：内核把行移入 view.groups[].rows/cards 并清空顶层行（SetItems(nil)），
+    // 这里聚合各分组当前页的行；总数取顶层 rowCount/cardCount（分页前全量）
+    const items: unknown[] = [];
+    for (const group of view.groups) {
+        if (!group || typeof group !== 'object' || Array.isArray(group)) continue;
+        const groupView = group as Record<string, unknown>;
+        const groupRows = Array.isArray(groupView.rows) ? groupView.rows
+            : Array.isArray(groupView.cards) ? groupView.cards
+                : [];
+        items.push(...groupRows);
+    }
+    return { items, total };
+}
+
+function computeRenderPageCount(view: Record<string, unknown> | undefined, total: number, effectivePageSize: number): number {
+    const base = computePageCount(total, effectivePageSize);
+    if (!Array.isArray(view?.groups)) return base;
+    // 分组视图的每组独立分页，hasNextPage 以组内最大页数为准
+    let count = base;
+    for (const group of view.groups) {
+        if (!group || typeof group !== 'object' || Array.isArray(group)) continue;
+        const groupView = group as Record<string, unknown>;
+        const groupTotal = typeof groupView.rowCount === 'number' ? groupView.rowCount as number
+            : typeof groupView.cardCount === 'number' ? groupView.cardCount as number
+                : 0;
+        if (groupTotal > 0) count = Math.max(count, computePageCount(groupTotal, effectivePageSize));
+    }
+    return count;
 }
 
 function buildAvTableView(responseObj: Record<string, unknown>, rows: unknown[], total: number): AvTableView | undefined {
@@ -1173,41 +1234,33 @@ async function handleRender({ client, permMgr, rawArgs }: ToolHandlerContext): P
     const responseObj = (response && typeof response === 'object' && !Array.isArray(response))
         ? response as Record<string, unknown>
         : {};
-    // SiYuan kernel nests the rendered view (columns/rows/rowCount) under `view`;
-    // fall back to flat top-level fields for older kernel response shapes.
+    // SiYuan kernel nests the rendered view under `view`：
+    // 表格 { pageSize, columns, rows, rowCount }（分组时行移入 view.groups[].rows），
+    // 画廊/看板 { pageSize, cards, cardCount }
     const view = (responseObj.view && typeof responseObj.view === 'object' && !Array.isArray(responseObj.view))
         ? responseObj.view as Record<string, unknown>
         : undefined;
-    const rows = (
-        Array.isArray(view?.rows) ? view.rows
-            : Array.isArray(responseObj.rows) ? responseObj.rows
-                : []
-    ) as unknown[];
+    const { items: rawRows, total } = extractViewItems(view);
     const page = parsed.page ?? 1;
-    const pageSize = parsed.pageSize ?? (rows.length || 1);
-    const total = typeof view?.rowCount === 'number'
-        ? view.rowCount as number
-        : typeof responseObj.rowCount === 'number'
-            ? responseObj.rowCount as number
-            : rows.length;
-    const kernelPageCount = typeof view?.pageCount === 'number'
-        ? view.pageCount as number
-        : typeof responseObj.pageCount === 'number'
-            ? responseObj.pageCount as number
-            : pageSize > 0 ? Math.max(1, Math.ceil(total / pageSize)) : 1;
-    const table = buildAvTableView(view ?? responseObj, rows, total);
-    const { rows: _ignoredRows, pageCount: _ignoredPageCount, rowCount: _ignoredRowCount, ...restResponse } = responseObj;
-    void _ignoredRows;
-    void _ignoredPageCount;
-    void _ignoredRowCount;
-    const result = createPaginatedResult(rows, {
+    // 内核分页：请求 pageSize<1（含 -1）时使用视图默认页大小（view.pageSize）
+    const effectivePageSize = (typeof parsed.pageSize === 'number' && parsed.pageSize > 0)
+        ? parsed.pageSize
+        : (typeof view?.pageSize === 'number' && view.pageSize > 0)
+            ? view.pageSize
+            : (rawRows.length || 1);
+    const kernelPageCount = computeRenderPageCount(view, total, effectivePageSize);
+    // 表格布局才构建归一化 table；data 用归一化行（避免原始行/table/view 三份重复）
+    const isTableLayout = Array.isArray(view?.columns);
+    const table = isTableLayout ? buildAvTableView(view as Record<string, unknown>, rawRows, total) : undefined;
+    const data = table?.rows ?? rawRows;
+    const result = createPaginatedResult(data, {
         total,
         page,
-        pageSize,
+        pageSize: effectivePageSize,
         pageCount: kernelPageCount,
         hasNextPage: page < kernelPageCount,
     }, {
-        ...restResponse,
+        ...responseObj,
         avID: effectiveAvID,
         id: effectiveAvID,
         ...(table ? { table } : {}),

--- a/src/tools/internal/pagination.ts
+++ b/src/tools/internal/pagination.ts
@@ -17,9 +17,13 @@ export function applyTruncation<T>(
     };
 }
 
+export function computePageCount(total: number, pageSize: number): number {
+    return Math.max(1, Math.ceil(total / pageSize));
+}
+
 export function paginate<T>(items: T[], page: number, pageSize: number): PaginationResult<T> {
     const total = items.length;
-    const pageCount = Math.max(1, Math.ceil(total / pageSize));
+    const pageCount = computePageCount(total, pageSize);
     const normalizedPage = Math.min(page, pageCount);
     const start = (normalizedPage - 1) * pageSize;
     const paged = items.slice(start, start + pageSize);

--- a/tests/unit/tools/av.test.ts
+++ b/tests/unit/tools/av.test.ts
@@ -130,6 +130,7 @@ describe('av tool', () => {
             viewType: 'table',
             view: {
                 id: 'view-1',
+                pageSize: 50,
                 columns: [],
                 rows: [],
                 rowCount: 0,
@@ -2263,7 +2264,7 @@ describe('av tool', () => {
             data: [],
             total: 0,
             page: 2,
-            pageSize: 1,
+            pageSize: 50,
             pageCount: 1,
             hasNextPage: false,
             avID: 'av-1',
@@ -2272,6 +2273,7 @@ describe('av tool', () => {
             viewType: 'table',
             view: {
                 id: 'view-1',
+                pageSize: 50,
                 columns: [],
                 rows: [],
                 rowCount: 0,
@@ -2288,14 +2290,17 @@ describe('av tool', () => {
             view: {
                 id: 'view-1',
                 name: '表格',
+                pageSize: 50,
                 columns: [
-                    { id: 'col-title', name: 'Title', type: 'text', pin: false, width: '200px' },
+                    { id: 'col-title', name: 'Title', type: 'text', pin: false, width: '200px', align: 0 },
+                    { id: 'col-done', name: '完成', type: 'checkbox', pin: false, width: '100px', align: 0 },
                 ],
                 rows: [
                     {
                         id: 'row-1',
                         cells: [
-                            { key: { id: 'col-title', name: 'Title', type: 'text' }, content: 'Paper A' },
+                            { id: 'val-1', value: { id: 'val-1', keyID: 'col-title', blockID: 'row-1', type: 0, text: { content: 'Paper A' } }, valueType: 0 },
+                            { id: 'val-2', value: { id: 'val-2', keyID: 'col-done', blockID: 'row-1', type: 10, checkbox: { checked: true } }, valueType: 10 },
                         ],
                     },
                 ],
@@ -2314,42 +2319,133 @@ describe('av tool', () => {
         expect(parsed).toMatchObject({
             avID: 'av-1',
             id: 'av-1',
-            data: [
-                {
-                    id: 'row-1',
-                    cells: [{ key: { id: 'col-title', name: 'Title', type: 'text' }, content: 'Paper A' }],
-                },
-            ],
+            data: [{ id: 'row-1', cells: { 'col-title': 'Paper A', 'col-done': true } }],
             total: 1,
+            pageSize: 50,
             table: {
-                columns: [{ id: 'col-title', name: 'Title', type: 'text' }],
-                rows: [{ id: 'row-1', cells: { 'col-title': 'Paper A' } }],
+                columns: [
+                    { id: 'col-title', name: 'Title', type: 'text' },
+                    { id: 'col-done', name: '完成', type: 'checkbox' },
+                ],
+                rows: [{ id: 'row-1', cells: { 'col-title': 'Paper A', 'col-done': true } }],
                 rowCount: 1,
             },
             view: {
                 id: 'view-1',
                 name: '表格',
-                rows: [{ id: 'row-1', cells: [{ key: { id: 'col-title' }, content: 'Paper A' }] }],
+                pageSize: 50,
+                rows: [{
+                    id: 'row-1',
+                    cells: [
+                        { id: 'val-1', value: { keyID: 'col-title', blockID: 'row-1', text: { content: 'Paper A' } } },
+                        { id: 'val-2', value: { keyID: 'col-done', blockID: 'row-1', checkbox: { checked: true } } },
+                    ],
+                }],
                 rowCount: 1,
             },
         });
     });
 
-    it('falls back to flat top-level rows when the kernel response has no nested view', async () => {
+    it('computes pagination from kernel rowCount and the effective page size', async () => {
+        const avApi = await import('@/api/av');
+        const view = {
+            id: 'view-1',
+            pageSize: 50,
+            columns: [{ id: 'col-title', name: 'Title', type: 'text' }],
+            rows: Array.from({ length: 20 }, (_, i) => ({
+                id: `row-${i + 1}`,
+                cells: [{ id: `val-${i + 1}`, value: { keyID: 'col-title', blockID: `row-${i + 1}`, text: { content: `Item ${i + 1}` } }, valueType: 0 }],
+            })),
+            rowCount: 120,
+        };
+        vi.mocked(avApi.renderAttributeView).mockResolvedValue({ id: 'av-1', viewID: 'view-1', viewType: 'table', view });
+
+        const result = await callAvTool(client, {
+            action: 'render',
+            id: 'av-1',
+            page: 3,
+        }, enabledActions('render'), permMgr);
+
+        const parsed = JSON.parse(result.content[0].text);
+        expect(parsed.data).toHaveLength(20);
+        expect(parsed.data[0]).toMatchObject({ id: 'row-1', cells: { 'col-title': 'Item 1' } });
+        expect(parsed.data[19]).toMatchObject({ id: 'row-20', cells: { 'col-title': 'Item 20' } });
+        expect(parsed).toMatchObject({
+            total: 120,
+            page: 3,
+            pageSize: 50,
+            pageCount: 3,
+            hasNextPage: false,
+        });
+    });
+
+    it('normalizes pageSize=-1 to the view default page size', async () => {
         const avApi = await import('@/api/av');
         vi.mocked(avApi.renderAttributeView).mockResolvedValue({
             id: 'av-1',
             viewID: 'view-1',
             viewType: 'table',
-            rows: [
-                {
-                    id: 'row-1',
-                    values: [
-                        { key: { id: 'col-title' }, content: 'Paper A' },
-                    ],
-                },
-            ],
-            rowCount: 1,
+            view: {
+                id: 'view-1',
+                pageSize: 50,
+                columns: [],
+                rows: [],
+                rowCount: 120,
+            },
+        });
+
+        const result = await callAvTool(client, {
+            action: 'render',
+            id: 'av-1',
+            pageSize: -1,
+        }, enabledActions('render'), permMgr);
+
+        const parsed = JSON.parse(result.content[0].text);
+        expect(parsed).toMatchObject({
+            data: [],
+            total: 120,
+            page: 1,
+            pageSize: 50,
+            pageCount: 3,
+            hasNextPage: true,
+        });
+    });
+
+    it('aggregates rows from group views when the kernel groups rows', async () => {
+        const avApi = await import('@/api/av');
+        vi.mocked(avApi.renderAttributeView).mockResolvedValue({
+            id: 'av-1',
+            viewID: 'view-1',
+            viewType: 'table',
+            view: {
+                id: 'view-1',
+                name: '分组表格',
+                pageSize: 50,
+                columns: [{ id: 'col-title', name: 'Title', type: 'text' }],
+                rows: [],
+                rowCount: 3,
+                groups: [
+                    {
+                        id: 'grp-1',
+                        name: 'A 组',
+                        pageSize: 50,
+                        rows: [
+                            { id: 'grow-1', cells: [{ id: 'gv-1', value: { keyID: 'col-title', blockID: 'grow-1', text: { content: 'Alpha' } }, valueType: 0 }] },
+                            { id: 'grow-2', cells: [{ id: 'gv-2', value: { keyID: 'col-title', blockID: 'grow-2', text: { content: 'Beta' } }, valueType: 0 }] },
+                        ],
+                        rowCount: 2,
+                    },
+                    {
+                        id: 'grp-2',
+                        name: 'B 组',
+                        pageSize: 50,
+                        rows: [
+                            { id: 'grow-3', cells: [{ id: 'gv-3', value: { keyID: 'col-title', blockID: 'grow-3', text: { content: 'Gamma' } }, valueType: 0 }] },
+                        ],
+                        rowCount: 1,
+                    },
+                ],
+            },
         });
 
         const result = await callAvTool(client, {
@@ -2358,15 +2454,22 @@ describe('av tool', () => {
         }, enabledActions('render'), permMgr);
 
         const parsed = JSON.parse(result.content[0].text);
+        expect(parsed.data).toHaveLength(3);
+        expect(parsed.data[0]).toMatchObject({ id: 'grow-1', cells: { 'col-title': 'Alpha' } });
+        expect(parsed.data[2]).toMatchObject({ id: 'grow-3', cells: { 'col-title': 'Gamma' } });
         expect(parsed).toMatchObject({
-            data: [
-                {
-                    id: 'row-1',
-                    values: [{ key: { id: 'col-title' }, content: 'Paper A' }],
-                },
-            ],
-            total: 1,
-            table: { rows: [{ id: 'row-1', cells: { 'col-title': 'Paper A' } }], rowCount: 1 },
+            total: 3,
+            pageSize: 50,
+            pageCount: 1,
+            hasNextPage: false,
+            table: {
+                rows: [
+                    { id: 'grow-1', cells: { 'col-title': 'Alpha' } },
+                    { id: 'grow-2', cells: { 'col-title': 'Beta' } },
+                    { id: 'grow-3', cells: { 'col-title': 'Gamma' } },
+                ],
+                rowCount: 3,
+            },
         });
     });
 
@@ -2404,8 +2507,13 @@ describe('av tool', () => {
             id: 'av-new',
             viewID: 'view-new',
             viewType: 'table',
-            columns: [{ name: '主键' }, { name: '单选' }],
-            rows: [],
+            view: {
+                id: 'view-new',
+                pageSize: 50,
+                columns: [{ name: '主键' }, { name: '单选' }],
+                rows: [],
+                rowCount: 0,
+            },
         });
         vi.mocked(avApi.getMirrorDatabaseBlocks).mockImplementation(async () => {
             const blockID = vi.mocked(transactionApi.performTransactions).mock.calls[0]?.[1]?.[0]?.doOperations?.[0]?.id;
@@ -2453,14 +2561,20 @@ describe('av tool', () => {
             data: [],
             total: 0,
             page: 1,
-            pageSize: 1,
+            pageSize: 50,
             pageCount: 1,
             hasNextPage: false,
             avID: 'av-new',
             id: 'av-new',
             viewID: 'view-new',
             viewType: 'table',
-            columns: [{ name: '主键' }, { name: '单选' }],
+            view: {
+                id: 'view-new',
+                pageSize: 50,
+                columns: [{ name: '主键' }, { name: '单选' }],
+                rows: [],
+                rowCount: 0,
+            },
             generatedAvID: false,
             materialized: true,
             blockID: insertedBlockID,
@@ -2479,8 +2593,13 @@ describe('av tool', () => {
             id: payload.id,
             viewID: 'view-new',
             viewType: 'table',
-            columns: [{ name: '主键' }, { name: '单选' }],
-            rows: [],
+            view: {
+                id: 'view-new',
+                pageSize: 50,
+                columns: [{ name: '主键' }, { name: '单选' }],
+                rows: [],
+                rowCount: 0,
+            },
         }));
         vi.mocked(avApi.getMirrorDatabaseBlocks).mockImplementation(async () => {
             const blockID = vi.mocked(transactionApi.performTransactions).mock.calls[0]?.[1]?.[0]?.doOperations?.[0]?.id;
@@ -2517,7 +2636,13 @@ describe('av tool', () => {
             blockID: insertedBlockID,
             parentID: 'target-doc',
             databaseBlockRegistrationVerified: true,
-            columns: [{ name: '主键' }, { name: '单选' }],
+            view: {
+                id: 'view-new',
+                pageSize: 50,
+                columns: [{ name: '主键' }, { name: '单选' }],
+                rows: [],
+                rowCount: 0,
+            },
         });
     });
 
@@ -2532,7 +2657,13 @@ describe('av tool', () => {
             id: 'av-missing',
             viewID: 'view-new',
             viewType: 'table',
-            rows: [],
+            view: {
+                id: 'view-new',
+                pageSize: 50,
+                columns: [],
+                rows: [],
+                rowCount: 0,
+            },
         });
         vi.mocked(avApi.getMirrorDatabaseBlocks).mockImplementation(async () => {
             const blockID = vi.mocked(transactionApi.performTransactions).mock.calls[0]?.[1]?.[0]?.doOperations?.[0]?.id;
@@ -2577,7 +2708,13 @@ describe('av tool', () => {
                 id: 'av-stuck',
                 viewID: 'view-new',
                 viewType: 'table',
-                rows: [],
+                view: {
+                    id: 'view-new',
+                    pageSize: 50,
+                    columns: [],
+                    rows: [],
+                    rowCount: 0,
+                },
             });
             vi.mocked(avApi.getMirrorDatabaseBlocks).mockResolvedValue({ refDefs: [] });
             vi.mocked(blockApi.getBlockDOM).mockResolvedValue({

--- a/tests/unit/tools/av.test.ts
+++ b/tests/unit/tools/av.test.ts
@@ -128,7 +128,12 @@ describe('av tool', () => {
             id: 'av-1',
             viewID: 'view-1',
             viewType: 'table',
-            rows: [],
+            view: {
+                id: 'view-1',
+                columns: [],
+                rows: [],
+                rowCount: 0,
+            },
         });
         vi.mocked(avApi.getAttributeViewKeys).mockResolvedValue([{ id: 'k1', name: 'Title' }]);
         vi.mocked(avApi.getAttributeViewPrimaryKeyValues).mockResolvedValue({
@@ -2265,27 +2270,37 @@ describe('av tool', () => {
             id: 'av-1',
             viewID: 'view-1',
             viewType: 'table',
+            view: {
+                id: 'view-1',
+                columns: [],
+                rows: [],
+                rowCount: 0,
+            },
         });
     });
 
-    it('accepts avID alias and adds a lightweight table view when render rows are parseable', async () => {
+    it('accepts avID alias and reads rows/columns from the kernel nested view structure', async () => {
         const avApi = await import('@/api/av');
         vi.mocked(avApi.renderAttributeView).mockResolvedValue({
             id: 'av-1',
             viewID: 'view-1',
             viewType: 'table',
-            keyValues: [
-                { key: { id: 'col-title', name: 'Title', type: 'text' } },
-            ],
-            rows: [
-                {
-                    id: 'row-1',
-                    values: [
-                        { key: { id: 'col-title' }, content: 'Paper A' },
-                    ],
-                },
-            ],
-            rowCount: 1,
+            view: {
+                id: 'view-1',
+                name: '表格',
+                columns: [
+                    { id: 'col-title', name: 'Title', type: 'text', pin: false, width: '200px' },
+                ],
+                rows: [
+                    {
+                        id: 'row-1',
+                        cells: [
+                            { key: { id: 'col-title', name: 'Title', type: 'text' }, content: 'Paper A' },
+                        ],
+                    },
+                ],
+                rowCount: 1,
+            },
         });
 
         const result = await callAvTool(client, {
@@ -2299,11 +2314,59 @@ describe('av tool', () => {
         expect(parsed).toMatchObject({
             avID: 'av-1',
             id: 'av-1',
+            data: [
+                {
+                    id: 'row-1',
+                    cells: [{ key: { id: 'col-title', name: 'Title', type: 'text' }, content: 'Paper A' }],
+                },
+            ],
+            total: 1,
             table: {
                 columns: [{ id: 'col-title', name: 'Title', type: 'text' }],
                 rows: [{ id: 'row-1', cells: { 'col-title': 'Paper A' } }],
                 rowCount: 1,
             },
+            view: {
+                id: 'view-1',
+                name: '表格',
+                rows: [{ id: 'row-1', cells: [{ key: { id: 'col-title' }, content: 'Paper A' }] }],
+                rowCount: 1,
+            },
+        });
+    });
+
+    it('falls back to flat top-level rows when the kernel response has no nested view', async () => {
+        const avApi = await import('@/api/av');
+        vi.mocked(avApi.renderAttributeView).mockResolvedValue({
+            id: 'av-1',
+            viewID: 'view-1',
+            viewType: 'table',
+            rows: [
+                {
+                    id: 'row-1',
+                    values: [
+                        { key: { id: 'col-title' }, content: 'Paper A' },
+                    ],
+                },
+            ],
+            rowCount: 1,
+        });
+
+        const result = await callAvTool(client, {
+            action: 'render',
+            id: 'av-1',
+        }, enabledActions('render'), permMgr);
+
+        const parsed = JSON.parse(result.content[0].text);
+        expect(parsed).toMatchObject({
+            data: [
+                {
+                    id: 'row-1',
+                    values: [{ key: { id: 'col-title' }, content: 'Paper A' }],
+                },
+            ],
+            total: 1,
+            table: { rows: [{ id: 'row-1', cells: { 'col-title': 'Paper A' } }], rowCount: 1 },
         });
     });
 


### PR DESCRIPTION
## 背景：Agent 通过 MCP 调用 av.render 时的实际困难

AI 客户端（Claude Code、Cline 等）通过 MCP 工具 `av.render` 读取思源笔记中数据库时，会遇到四类问题：

1. **行数据恒为空**：`renderAttributeView` 的真实响应把行/列/总数放在嵌套的 `view` 对象中（`view.rows` / `view.columns` / `view.rowCount`），而 handler 只读顶层 `rows`。Agent 每次调用都拿到空数据，无法基于数据库内容作答，表格视图（`table`）也构建不出来。
2. **翻页语义错误导致 Agent 误判**：内核在请求 `pageSize<1`（MCP 客户端常传 `-1`）时回退到视图默认页大小；原实现对 `-1` 按 1 条截断、`hasNextPage` 恒为真。Agent 要么只看一页就误以为翻完，要么陷入无限翻页。
3. **分组视图行数据整体丢失**：按字段分组时内核把行移入 `view.groups[].rows` 并清空顶层行（`SetItems(nil)`），分组数据库在 Agent 视角下整库为空。
4. **Cell 解析错位**：内核渲染 cell 的列 ID 在 `cell.value.keyID`（顶层 `id` 是值 ID），值在 `value.text.content` / `value.checkbox.checked` 等类型子对象；原实现按错误路径取值，列内容错乱或缺失。

遇到这些问题后，Agent 会转而用非常缓慢的方法逐行读取数据库，浪费 token 和时间。

## 修复

- **行读取**：从 `view.rows`（表格/列表）或 `view.cards`（画廊/看板）提取；分组视图聚合 `view.groups[].rows/cards`，总数取 `rowCount/cardCount`（分页前全量）
- **Cell 解析**：列 ID 从 `cell.value.keyID` 取；标量值从类型子对象解包（`text.content`→字符串、`checkbox.checked`→布尔），多值/引用类（mSelect/relation/block）原样返回
- **分页**：`pageSize<1` 归一化为 `view.pageSize`；`pageCount` 按 `rowCount / 生效页大小` 计算（复用 `computePageCount`），分组视图取组内最大页数；`data` 与 `table.rows` 一致，消除三份重复
- **清理**：删除不存在的顶层平铺回退与 `view.pageCount` 死分支

## 验证

- 单测 1020/1020 通过（av 相关 67 个，新增：多页分页、`pageSize=-1` 归一化、分组聚合）
- 已构建部署本地实例实测：`pageSize: 50`、`table.columns` 为真实列、`view` 完整透出

## 说明

本 PR 由 deepseek-v4-flash-0731 + claude 完成，但 PR 文本（当然也包括这段文字）和实际修复效果皆由本人 review 和实机验证。